### PR TITLE
Bugfix for PacketMapChun (0x33)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,13 @@
 			<artifactId>bcprov-jdk15on</artifactId>
 			<version>1.47</version>
 		</dependency>
+		<dependency>
+			<!-- globally use junit 4.10 -->
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.10</version>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/ch/spacebase/mcprotocol/event/PacketReceiveEvent.java
+++ b/src/main/java/ch/spacebase/mcprotocol/event/PacketReceiveEvent.java
@@ -2,11 +2,11 @@ package ch.spacebase.mcprotocol.event;
 
 import ch.spacebase.mcprotocol.packet.Packet;
 
-public class PacketRecieveEvent extends ProtocolEvent<ProtocolListener> {
+public class PacketReceiveEvent extends ProtocolEvent<ProtocolListener> {
 
 	private Packet packet;
 
-	public PacketRecieveEvent(Packet packet) {
+	public PacketReceiveEvent(Packet packet) {
 		this.packet = packet;
 	}
 

--- a/src/main/java/ch/spacebase/mcprotocol/event/ProtocolListener.java
+++ b/src/main/java/ch/spacebase/mcprotocol/event/ProtocolListener.java
@@ -2,7 +2,7 @@ package ch.spacebase.mcprotocol.event;
 
 public abstract class ProtocolListener {
 
-	public abstract void onPacketRecieve(PacketRecieveEvent event);
+	public abstract void onPacketRecieve(PacketReceiveEvent event);
 	
 	public abstract void onPacketSend(PacketSendEvent event);
 	

--- a/src/main/java/ch/spacebase/mcprotocol/net/Connection.java
+++ b/src/main/java/ch/spacebase/mcprotocol/net/Connection.java
@@ -14,7 +14,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 import ch.spacebase.mcprotocol.event.DisconnectEvent;
-import ch.spacebase.mcprotocol.event.PacketRecieveEvent;
+import ch.spacebase.mcprotocol.event.PacketReceiveEvent;
 import ch.spacebase.mcprotocol.event.PacketSendEvent;
 import ch.spacebase.mcprotocol.event.ProtocolEvent;
 import ch.spacebase.mcprotocol.event.ProtocolListener;
@@ -148,7 +148,7 @@ public abstract class Connection {
 						packet.handleServer((ServerConnection) Connection.this);
 					}
 
-					call(new PacketRecieveEvent(packet));
+					call(new PacketReceiveEvent(packet));
 					reading = false;
 				} catch(EOFException e) {
 					disconnect("End of Stream");

--- a/src/main/java/ch/spacebase/mcprotocol/standard/example/ChatBot.java
+++ b/src/main/java/ch/spacebase/mcprotocol/standard/example/ChatBot.java
@@ -3,7 +3,7 @@ package ch.spacebase.mcprotocol.standard.example;
 import java.text.DecimalFormat;
 
 import ch.spacebase.mcprotocol.event.DisconnectEvent;
-import ch.spacebase.mcprotocol.event.PacketRecieveEvent;
+import ch.spacebase.mcprotocol.event.PacketReceiveEvent;
 import ch.spacebase.mcprotocol.event.PacketSendEvent;
 import ch.spacebase.mcprotocol.event.ProtocolListener;
 import ch.spacebase.mcprotocol.exception.ConnectException;
@@ -55,7 +55,7 @@ public class ChatBot {
 
 	private class Listener extends ProtocolListener {
 		@Override
-		public void onPacketRecieve(PacketRecieveEvent event) {
+		public void onPacketRecieve(PacketReceiveEvent event) {
 			Packet packet = event.getPacket();
 
 			switch(event.getPacket().getId()) {

--- a/src/main/java/ch/spacebase/mcprotocol/standard/packet/PacketMapChunk.java
+++ b/src/main/java/ch/spacebase/mcprotocol/standard/packet/PacketMapChunk.java
@@ -85,7 +85,7 @@ public class PacketMapChunk extends Packet {
 		out.writeBoolean(this.groundUp);
 		out.writeShort((short) (this.startY & 0xffff));
 		out.writeShort((short) (this.endY & 0xffff));
-		out.writeByte(this.length);
+		out.writeInt(this.length);
 		out.write(this.data, 0, this.length);
 	}
 

--- a/src/test/java/ch/spacebase/mcprotocol/util/IOUtilsTest.java
+++ b/src/test/java/ch/spacebase/mcprotocol/util/IOUtilsTest.java
@@ -1,0 +1,37 @@
+package ch.spacebase.mcprotocol.util;
+
+import static org.junit.Assert.*;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class IOUtilsTest {
+
+	@Before
+	public void setUp() throws Exception {
+	}
+
+	@Test
+	public void testReadMetadata() {
+		try {
+			ByteArrayOutputStream data = new ByteArrayOutputStream();
+			DataOutputStream d = new DataOutputStream(data);
+			d.writeByte(127);
+
+			DataInputStream in = new DataInputStream(new ByteArrayInputStream(((ByteArrayOutputStream) data).toByteArray()));
+
+			int b = in.readUnsignedByte();
+			assertEquals(127, b);
+		} catch (IOException e) {
+			e.printStackTrace();
+			fail("IOException should not occur");
+		}
+	}
+
+}


### PR DESCRIPTION
The length of PacketMapChun was not written as an integer, causing a client to loose sync with the server...

Thanks Herman!
