### PR TITLE
Fix Incorrect Packet Data

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerStatisticsPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerStatisticsPacket.java
@@ -34,6 +34,7 @@ public class ServerStatisticsPacket implements Packet {
 
 	@Override
 	public void write(NetOutput out) throws IOException {
+		out.writeVarInt(statistics.size());
 		for(String statistic : this.statistics.keySet()) {
 			out.writeString(statistic);
 			out.writeVarInt(this.statistics.get(statistic));


### PR DESCRIPTION
The specifications for a Stat Packet has a VarInt of the length sent before the data so the client knows how much data to read.
