### PR TITLE
Close GZIPOutputStream

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/util/NetUtil.java
+++ b/src/main/java/org/spacehq/mc/protocol/util/NetUtil.java
@@ -28,8 +28,10 @@ public class NetUtil {
 			out.writeShort(-1);
 		} else {
 			ByteArrayOutputStream output = new ByteArrayOutputStream();
-			NBTIO.writeTag(new DataOutputStream(new GZIPOutputStream(output)), tag);
+			GZIPOutputStream gzip;
+			NBTIO.writeTag(new DataOutputStream(gzip = new GZIPOutputStream(output)), tag);
 			output.close();
+			gzip.close();
 			byte bytes[] = output.toByteArray();
 			out.writeShort((short) bytes.length);
 			out.writeBytes(bytes);


### PR DESCRIPTION
Without closing it, it causes the client to throw ZLIB not closed errors and disconnect :(. Luckily this fixes it!
