### PR TITLE
Fix an issue where the client will attempt to read too many varints

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPlayerPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPlayerPacket.java
@@ -78,7 +78,8 @@ public class ServerSpawnPlayerPacket implements Packet {
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.profile = new GameProfile(in.readString(), in.readString());
-		for(int count = 0; count < in.readVarInt(); count++) {
+		int numProperties = in.readVarInt();
+		for(int count = 0; count < numProperties; count++) {
 			String name = in.readString();
 			String value = in.readString();
 			String signature = in.readString();


### PR DESCRIPTION
In Java the condition in a for loop is calculated after every loop run. If there is enough properties to justify another loop, the client will attempt to read another varint which isn't there. I fixed this by reading the number of properties prior to the for loop.
