### PR TITLE
Fixed StackOverflowError

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/data/message/MessageStyle.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/message/MessageStyle.java
@@ -4,13 +4,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class MessageStyle implements Cloneable {
+	public static final MessageStyle DEFAULT = new MessageStyle();
 
 	private ChatColor color = ChatColor.WHITE;
 	private List<ChatFormat> formats = new ArrayList<ChatFormat>();
 	private ClickEvent click;
 	private HoverEvent hover;
 	private String insertion;
-	private MessageStyle parent = new MessageStyle();
+	private MessageStyle parent = MessageStyle.DEFAULT;
 
 	public boolean isDefault() {
 		return this.color == this.parent.getColor() && this.formatListsEqual(this.formats, this.parent.getFormats()) && this.click == null && this.hover == null && this.insertion == null;


### PR DESCRIPTION
Now it does not throw **stack overflow exception**. Instead of creating new (I suppose default MessageStyle) in constructor of each instance of MessageStyle, It points at ONE constant default message style, so the exception is not thrown.
