### PR TITLE
Fix ServerEntityRemoveEffectPacket

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityRemoveEffectPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityRemoveEffectPacket.java
@@ -32,13 +32,13 @@ public class ServerEntityRemoveEffectPacket implements Packet {
 
 	@Override
 	public void read(NetInput in) throws IOException {
-		this.entityId = in.readInt();
+		this.entityId = in.readVarInt();
 		this.effect = MagicValues.key(Effect.class, in.readByte());
 	}
 
 	@Override
 	public void write(NetOutput out) throws IOException {
-		out.writeInt(this.entityId);
+		out.writeVarInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.effect));
 	}
 


### PR DESCRIPTION
A small mistake in ServerEntityRemoveEffectPacket causes crashes.
As according to [wiki.vg](http://wiki.vg/Protocol#Remove_Entity_Effect), this packet uses a _Var_Int, not an Int.
This is a simple patch to fix it.

I have tested this patch locally, and it fixes the crash bug in question.
