### PR TITLE
ServerEntityPropertiesPacket & ServerUpdateScorePacket fixes

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityPropertiesPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityPropertiesPacket.java
@@ -58,11 +58,11 @@ public class ServerEntityPropertiesPacket implements Packet {
 	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
-		out.writeVarInt(this.attributes.size());
+		out.writeInt(this.attributes.size());
 		for(Attribute attribute : this.attributes) {
 			out.writeString(MagicValues.value(String.class, attribute.getType()));
 			out.writeDouble(attribute.getValue());
-			out.writeShort(attribute.getModifiers().size());
+			out.writeVarInt(attribute.getModifiers().size());
 			for(AttributeModifier modifier : attribute.getModifiers()) {
 				UUID uuid = MagicValues.value(UUID.class, modifier.getType());
 				out.writeUUID(uuid);

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerUpdateScorePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerUpdateScorePacket.java
@@ -51,8 +51,8 @@ public class ServerUpdateScorePacket implements Packet {
 	public void read(NetInput in) throws IOException {
 		this.entry = in.readString();
 		this.action = MagicValues.key(ScoreboardAction.class, in.readByte());
+		this.objective = in.readString();
 		if(this.action == ScoreboardAction.ADD_OR_UPDATE) {
-			this.objective = in.readString();
 			this.value = in.readVarInt();
 		}
 	}
@@ -61,8 +61,8 @@ public class ServerUpdateScorePacket implements Packet {
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.entry);
 		out.writeByte(MagicValues.value(Integer.class, this.action));
+		out.writeString(this.objective);
 		if(this.action == ScoreboardAction.ADD_OR_UPDATE) {
-			out.writeString(this.objective);
 			out.writeVarInt(this.value);
 		}
 	}


### PR DESCRIPTION
This PR fixes invalid data types in `ServerEntityPropertiesPacket` and always sends/reads the name of the objective in the `ServerUpdateScorePacket`.
Both previously caused the client to close the connection.

`ServerEntityPropertiesPacket`: http://wiki.vg/Protocol#Entity_Properties
`ServerUpdateScorePacket`: http://wiki.vg/Protocol#Update_Score
