### PR TITLE
Fix Rotation throwing IOException in writeEntityMetadata

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/util/NetUtil.java
+++ b/src/main/java/org/spacehq/mc/protocol/util/NetUtil.java
@@ -177,6 +177,7 @@ public class NetUtil {
 					out.writeFloat(rot.getPitch());
 					out.writeFloat(rot.getYaw());
 					out.writeFloat(rot.getRoll());
+					break;
 				default:
 					throw new IOException("Unmapped metadata type: " + meta.getType());
 			}


### PR DESCRIPTION
Does what it says. It's basically just a missing break in the switch statement causing it to fall through to the default case.
Feel free to commit it yourself, imho it's not worth a merge. But do whatever's more convenient for you.
