### PR TITLE
Handle 'FriedlyFire' byte as flags

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/MagicValues.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/MagicValues.java
@@ -332,10 +332,6 @@ public class MagicValues {
 		register(TeamAction.ADD_PLAYER, 3);
 		register(TeamAction.REMOVE_PLAYER, 4);
 
-		register(FriendlyFire.OFF, 0);
-		register(FriendlyFire.ON, 1);
-		register(FriendlyFire.FRIENDLY_INVISIBLES_VISIBLE, 3);
-
 		register(ScoreboardAction.ADD_OR_UPDATE, 0);
 		register(ScoreboardAction.REMOVE, 1);
 

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/scoreboard/FriendlyFire.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/scoreboard/FriendlyFire.java
@@ -1,9 +1,0 @@
-package org.spacehq.mc.protocol.data.game.values.scoreboard;
-
-public enum FriendlyFire {
-
-	OFF,
-	ON,
-	FRIENDLY_INVISIBLES_VISIBLE;
-
-}


### PR DESCRIPTION
The `FriendlyFire` byte sent in the `ServerTeamPacket` should actually be read as a flag field with `0x1` being the actual friendly fire and `0x2` being whether team members can see each other even though they are invisible.
Having friendly fire disabled and visibility of team members active (the resulting byte is therefore `0x2`) causes the current implementation to throw NPEs when writing a previously read packet.

The above bug is fixed by this PR as well as allowing distinct access to both flags and removing the misleading/incorrect `FriendlyFire` interface.

Note: The documentation at [wiki.vg](http://wiki.vg/Protocol#Teams) seems to be misleading/incorrect.
