### PR TITLE
Armor stands can be spawned using the ServerSpawnMobPacket

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/MagicValues.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/MagicValues.java
@@ -227,6 +227,7 @@ public class MagicValues {
 
 		register(GlobalEntityType.LIGHTNING_BOLT, 1);
 
+		register(MobType.ARMOR_STAND, 30);
 		register(MobType.CREEPER, 50);
 		register(MobType.SKELETON, 51);
 		register(MobType.SPIDER, 52);

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/entity/MobType.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/entity/MobType.java
@@ -2,6 +2,7 @@ package org.spacehq.mc.protocol.data.game.values.entity;
 
 public enum MobType {
 
+	ARMOR_STAND,
 	CREEPER,
 	SKELETON,
 	SPIDER,


### PR DESCRIPTION
For some bizarre reason the vanilla minecraft client allows the server to spawn armor stands using the `ServerSpawnMobPacket` (with type id 30). The only server that I've seen doing so is the Hypixel server (though I haven't tested any other big minigame networks).
Vanilla servers seem to use the `ServerSpawnObjectPacket` (with type id 78) as expected. However due to the fact that the vanilla client **does** handle these correctly (and displays them) MCProtocolLib should support them as well.

I've also tested other `ObjectType`s but they all seem to be ignored by the vanilla client.

This PR fixes the NPE thrown when reading and subsequently writing such a packet.
