### PR TITLE
Add missing world types, fixed typo

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/MagicValues.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/MagicValues.java
@@ -161,8 +161,10 @@ public class MagicValues {
 
 		register(WorldType.DEFAULT, "default");
 		register(WorldType.FLAT, "flat");
-		register(WorldType.LARGE_BIOMES, "largeBiomes");
+		register(WorldType.LARGE_BIOMES, "largebiomes");
 		register(WorldType.AMPLIFIED, "amplified");
+		register(WorldType.CUSTOMIZED, "customized");
+		register(WorldType.DEBUG, "debug_all_block_states");
 		register(WorldType.DEFAULT_1_1, "default_1_1");
 
 		register(Animation.SWING_ARM, 0);

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/world/WorldType.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/world/WorldType.java
@@ -6,6 +6,8 @@ public enum WorldType {
 	FLAT,
 	LARGE_BIOMES,
 	AMPLIFIED,
+	CUSTOMIZED,
+	DEBUG,
 	DEFAULT_1_1;
 
 }


### PR DESCRIPTION
This PR adds the world types `CUSTOMIZED` (`customized`) and `DEBUG` (`debug_all_block_states`).
This also fixes a typo which caused the `LARGE_BIOMES` type not to be recognized (incorrect capitalization).

Links:
- [level.dat format / generatorName](http://minecraft.gamepedia.com/Level_format)
