### PR TITLE
Split window properties into separate enums for separate window types

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/MagicValues.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/MagicValues.java
@@ -8,6 +8,10 @@ import org.spacehq.mc.protocol.data.game.values.setting.Difficulty;
 import org.spacehq.mc.protocol.data.game.values.statistic.Achievement;
 import org.spacehq.mc.protocol.data.game.values.statistic.GenericStatistic;
 import org.spacehq.mc.protocol.data.game.values.window.*;
+import org.spacehq.mc.protocol.data.game.values.window.property.AnvilProperty;
+import org.spacehq.mc.protocol.data.game.values.window.property.BrewingStandProperty;
+import org.spacehq.mc.protocol.data.game.values.window.property.EnchantmentTableProperty;
+import org.spacehq.mc.protocol.data.game.values.window.property.FurnaceProperty;
 import org.spacehq.mc.protocol.data.game.values.world.GenericSound;
 import org.spacehq.mc.protocol.data.game.values.world.Particle;
 import org.spacehq.mc.protocol.data.game.values.world.WorldBorderAction;
@@ -371,9 +375,22 @@ public class MagicValues {
 		register(WindowType.VILLAGER, "minecraft:villager");
 		register(WindowType.HORSE, "EntityHorse");
 
-		register(WindowProperty.FURNACE_PROGRESS_OR_ENCHANT_1, 0);
-		register(WindowProperty.FURNACE_FUEL_OR_ENCHANT_2, 1);
-		register(WindowProperty.ENCHANT_3, 2);
+		register(BrewingStandProperty.BREW_TIME, 0);
+
+		register(EnchantmentTableProperty.LEVEL_SLOT_1, 0);
+		register(EnchantmentTableProperty.LEVEL_SLOT_2, 1);
+		register(EnchantmentTableProperty.LEVEL_SLOT_3, 2);
+		register(EnchantmentTableProperty.XP_SEED, 3);
+		register(EnchantmentTableProperty.ENCHANTMENT_SLOT_1, 4);
+		register(EnchantmentTableProperty.ENCHANTMENT_SLOT_2, 5);
+		register(EnchantmentTableProperty.ENCHANTMENT_SLOT_3, 6);
+
+		register(FurnaceProperty.BURN_TIME, 0);
+		register(FurnaceProperty.CURRENT_ITEM_BURN_TIME, 1);
+		register(FurnaceProperty.COOK_TIME, 2);
+		register(FurnaceProperty.TOTAL_COOK_TIME, 3);
+
+		register(AnvilProperty.MAXIMUM_COST, 0);
 
 		register(BlockBreakStage.RESET, -1);
 		register(BlockBreakStage.STAGE_1, 0);

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/window/WindowProperty.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/window/WindowProperty.java
@@ -1,9 +1,0 @@
-package org.spacehq.mc.protocol.data.game.values.window;
-
-public enum WindowProperty {
-
-	FURNACE_PROGRESS_OR_ENCHANT_1,
-	FURNACE_FUEL_OR_ENCHANT_2,
-	ENCHANT_3;
-
-}

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/AnvilProperty.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/AnvilProperty.java
@@ -1,0 +1,11 @@
+package org.spacehq.mc.protocol.data.game.values.window.property;
+
+/**
+ * Window properties of an anvil.
+ */
+public enum AnvilProperty {
+    /**
+     * The maximum cost of renaming or repairing in the anvil.
+     */
+    MAXIMUM_COST,
+}

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/BrewingStandProperty.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/BrewingStandProperty.java
@@ -1,0 +1,12 @@
+package org.spacehq.mc.protocol.data.game.values.window.property;
+
+/**
+ * Window properties of a brewing stand.
+ */
+public enum BrewingStandProperty implements WindowProperty {
+    /**
+     * Time remaining for potions to finish brewing.
+     * Usually a value between 0 (done) and 400 (just started).
+     */
+    BREW_TIME,
+}

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/EnchantmentTableProperty.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/EnchantmentTableProperty.java
@@ -1,0 +1,77 @@
+package org.spacehq.mc.protocol.data.game.values.window.property;
+
+/**
+ * Window properties of an enchantment table.
+ */
+public enum EnchantmentTableProperty implements WindowProperty {
+
+    /**
+     * Level of the enchantment in slot 1.
+     */
+    LEVEL_SLOT_1,
+
+    /**
+     * Level of the enchantment in slot 2.
+     */
+    LEVEL_SLOT_2,
+
+    /**
+     * Level of the enchantment in slot 3.
+     */
+    LEVEL_SLOT_3,
+
+    /**
+     * The seed used for the next enchantment.
+     */
+    XP_SEED,
+
+    /**
+     * The enchantment for slot 1.
+     * @see #getEnchantment(int, int)
+     */
+    ENCHANTMENT_SLOT_1,
+
+    /**
+     * The enchantment for slot 2.
+     * @see #getEnchantment(int, int)
+     */
+    ENCHANTMENT_SLOT_2,
+
+    /**
+     * The enchantment for slot 3.
+     * @see #getEnchantment(int, int)
+     */
+    ENCHANTMENT_SLOT_3;
+
+    /**
+     * Packs enchantment type and level into one integer as used for the ENCHANTMENT_SLOT_X properties.
+     * @param type Id of the enchantment
+     * @param level Level of the enchantment
+     * @return Packed value
+     * @see #getEnchantmentType(int)
+     * @see #getEnchantmentLevel(int)
+     */
+    public static int getEnchantment(int type, int level) {
+        return type | level << 8;
+    }
+
+    /**
+     * Unpacks the enchantment type from one integer as used for the ENCHANTMENT_SLOT_X properties.
+     * @param enchantmentInfo Packed value
+     * @return Id of the enchantment
+     * @see #getEnchantment(int, int)
+     */
+    public static int getEnchantmentType(int enchantmentInfo) {
+        return enchantmentInfo & 0xff;
+    }
+
+    /**
+     * Unpacks the enchantment level from one integer as used for the ENCHANTMENT_SLOT_X properties.
+     * @param enchantmentInfo Packed value
+     * @return Level of the enchantment
+     * @see #getEnchantment(int, int)
+     */
+    public static int getEnchantmentLevel(int enchantmentInfo) {
+        return enchantmentInfo >> 8;
+    }
+}

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/FurnaceProperty.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/FurnaceProperty.java
@@ -1,0 +1,27 @@
+package org.spacehq.mc.protocol.data.game.values.window.property;
+
+/**
+ * Window properties of a furnace.
+ */
+public enum FurnaceProperty {
+
+    /**
+     * Number of ticks left before the current fuel runs out.
+     */
+    BURN_TIME,
+
+    /**
+     * Number of ticks that the current item can keep the furnace burning.
+     */
+    CURRENT_ITEM_BURN_TIME,
+
+    /**
+     * Number of ticks the item has been smelting for.
+     */
+    COOK_TIME,
+
+    /**
+     * Number of ticks that the current item needs to be smelted.
+     */
+    TOTAL_COOK_TIME,
+}

--- a/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/WindowProperty.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/game/values/window/property/WindowProperty.java
@@ -1,0 +1,5 @@
+package org.spacehq.mc.protocol.data.game.values.window.property;
+
+public interface WindowProperty {
+
+}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerWindowPropertyPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerWindowPropertyPacket.java
@@ -1,7 +1,7 @@
 package org.spacehq.mc.protocol.packet.ingame.server.window;
 
 import org.spacehq.mc.protocol.data.game.values.MagicValues;
-import org.spacehq.mc.protocol.data.game.values.window.WindowProperty;
+import org.spacehq.mc.protocol.data.game.values.window.property.WindowProperty;
 import org.spacehq.packetlib.io.NetInput;
 import org.spacehq.packetlib.io.NetOutput;
 import org.spacehq.packetlib.packet.Packet;
@@ -11,16 +11,22 @@ import java.io.IOException;
 public class ServerWindowPropertyPacket implements Packet {
 
 	private int windowId;
-	private WindowProperty property;
+	private int property;
 	private int value;
 
 	@SuppressWarnings("unused")
 	private ServerWindowPropertyPacket() {
 	}
 
-	public ServerWindowPropertyPacket(int windowId, WindowProperty property, int value) {
+	public ServerWindowPropertyPacket(int windowId, int property, int value) {
 		this.windowId = windowId;
 		this.property = property;
+		this.value = value;
+	}
+
+	public <T extends Enum<T> & WindowProperty> ServerWindowPropertyPacket(int windowId, T property, int value) {
+		this.windowId = windowId;
+		this.property = MagicValues.value(Integer.class, property);
 		this.value = value;
 	}
 
@@ -28,8 +34,12 @@ public class ServerWindowPropertyPacket implements Packet {
 		return this.windowId;
 	}
 
-	public WindowProperty getProperty() {
+	public int getRawProperty() {
 		return this.property;
+	}
+
+	public <T extends Enum<T> & WindowProperty> T getProperty(Class<T> type) {
+		return MagicValues.key(type, value);
 	}
 
 	public int getValue() {
@@ -39,14 +49,14 @@ public class ServerWindowPropertyPacket implements Packet {
 	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readUnsignedByte();
-		this.property = MagicValues.key(WindowProperty.class, in.readShort());
+		this.property = in.readShort();
 		this.value = in.readShort();
 	}
 
 	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
-		out.writeShort(MagicValues.value(Integer.class, this.property));
+		out.writeShort(this.property);
 		out.writeShort(this.value);
 	}
 


### PR DESCRIPTION
### Why is this change necessary?

This PR changes how window properties are handled which breaks backwards compatibility with programs using these classes.
However this change is necessary due to the fact that as of 1.8 there are seven different properties and e.g. up to four meanings for one of them. The alternative of having enum values named `BREW_TIME_OR_FURNACE_PROGRESS_OR_ENCHANT_1_OR_REPAIR_MAXIMUM_COST` is just ugly.
### The new `WindowProperty` structure

First of all, `WindowProperty` is now an `interface` instead of an `enum`. This is in order to allow different windows to have different properties. The different window properties themselves are `enum`s and implement the `WindowProperty` interface. They are located in the `data/game/values/window/property` package. Documentation for each of the properties is provided as their precise purpose might be hard to guess from their names.
In addition the `EnchantmentTableProperty` provides three static methods to pack/unpack an enchantment level and type into one integer as it's used by the `ENCHANTMENT_SLOT_X` properties.
### Changes to the window property packet

The `ServerWindowPropertyPacket` does not know which window type the current window has, therefore it stores the window type as a raw integer. It also provides a constructor and a getter for this value.
The main way of accessing the window property now would be to use the new getter which takes the expected type of window property and returns the appropriate property.
A constructor for creating a new packet using one of the window properties is provided as well.
