### PR TITLE
Fix Interface Methods

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/packet/handshake/client/HandshakePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/handshake/client/HandshakePacket.java
@@ -42,7 +42,6 @@ public class HandshakePacket implements Packet {
 		return this.intent;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.protocolVersion = in.readVarInt();
 		this.hostname = in.readString();
@@ -50,7 +49,6 @@ public class HandshakePacket implements Packet {
 		this.intent = MagicValues.key(HandshakeIntent.class, in.readVarInt());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.protocolVersion);
 		out.writeString(this.hostname);
@@ -58,7 +56,6 @@ public class HandshakePacket implements Packet {
 		out.writeVarInt(MagicValues.value(Integer.class, this.intent));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientChatPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientChatPacket.java
@@ -22,17 +22,14 @@ public class ClientChatPacket implements Packet {
 		return this.message;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.message = in.readString();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.message);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientKeepAlivePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientKeepAlivePacket.java
@@ -22,17 +22,14 @@ public class ClientKeepAlivePacket implements Packet {
 		return this.id;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.id = in.readVarInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.id);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientPluginMessagePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientPluginMessagePacket.java
@@ -28,19 +28,16 @@ public class ClientPluginMessagePacket implements Packet {
 		return this.data;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.channel = in.readString();
 		this.data = in.readBytes(in.available());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.channel);
 		out.writeBytes(this.data);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientRequestPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientRequestPacket.java
@@ -24,17 +24,14 @@ public class ClientRequestPacket implements Packet {
 		return this.request;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.request = MagicValues.key(ClientRequest.class, in.readUnsignedByte());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(MagicValues.value(Integer.class, this.request));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientResourcePackStatusPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientResourcePackStatusPacket.java
@@ -29,19 +29,16 @@ public class ClientResourcePackStatusPacket implements Packet {
 		return this.status;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.hash = in.readString();
 		this.status = MagicValues.key(ResourcePackStatus.class, in.readVarInt());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.hash);
 		out.writeVarInt(MagicValues.value(Integer.class, this.status));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientSettingsPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientSettingsPacket.java
@@ -52,7 +52,6 @@ public class ClientSettingsPacket implements Packet {
 		return this.visibleParts;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.locale = in.readString();
 		this.renderDistance = in.readByte();
@@ -68,7 +67,6 @@ public class ClientSettingsPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.locale);
 		out.writeByte(this.renderDistance);
@@ -82,7 +80,6 @@ public class ClientSettingsPacket implements Packet {
 		out.writeByte(flags);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientTabCompletePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/ClientTabCompletePacket.java
@@ -30,13 +30,11 @@ public class ClientTabCompletePacket implements Packet {
 		return this.text;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.text = in.readString();
 		this.position = in.readBoolean() ? NetUtil.readPosition(in) : null;
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.text);
 		out.writeBoolean(this.position != null);
@@ -45,7 +43,6 @@ public class ClientTabCompletePacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientChangeHeldItemPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientChangeHeldItemPacket.java
@@ -22,17 +22,14 @@ public class ClientChangeHeldItemPacket implements Packet {
 		return this.slot;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.slot = in.readShort();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeShort(this.slot);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerAbilitiesPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerAbilitiesPacket.java
@@ -52,7 +52,6 @@ public class ClientPlayerAbilitiesPacket implements Packet {
 		return this.walkSpeed;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		byte flags = in.readByte();
 		this.invincible = (flags & 1) > 0;
@@ -63,7 +62,6 @@ public class ClientPlayerAbilitiesPacket implements Packet {
 		this.walkSpeed = in.readFloat();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		byte flags = 0;
 		if(this.invincible) {
@@ -87,7 +85,6 @@ public class ClientPlayerAbilitiesPacket implements Packet {
 		out.writeFloat(this.walkSpeed);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerActionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerActionPacket.java
@@ -39,21 +39,18 @@ public class ClientPlayerActionPacket implements Packet {
 		return this.face;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.action = MagicValues.key(PlayerAction.class, in.readUnsignedByte());
 		this.position = NetUtil.readPosition(in);
 		this.face = MagicValues.key(Face.class, in.readUnsignedByte());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(MagicValues.value(Integer.class, this.action));
 		NetUtil.writePosition(out, this.position);
 		out.writeByte(MagicValues.value(Integer.class, this.face));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerInteractEntityPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerInteractEntityPacket.java
@@ -41,7 +41,6 @@ public class ClientPlayerInteractEntityPacket implements Packet {
 		return this.action;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.action = MagicValues.key(InteractAction.class, in.readVarInt());
@@ -52,7 +51,6 @@ public class ClientPlayerInteractEntityPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeVarInt(MagicValues.value(Integer.class, this.action));
@@ -63,7 +61,6 @@ public class ClientPlayerInteractEntityPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerMovementPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerMovementPacket.java
@@ -49,7 +49,6 @@ public class ClientPlayerMovementPacket implements Packet {
 		return this.onGround;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		if(this.pos) {
 			this.x = in.readDouble();
@@ -65,7 +64,6 @@ public class ClientPlayerMovementPacket implements Packet {
 		this.onGround = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		if(this.pos) {
 			out.writeDouble(this.x);
@@ -81,7 +79,6 @@ public class ClientPlayerMovementPacket implements Packet {
 		out.writeBoolean(this.onGround);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerPlaceBlockPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerPlaceBlockPacket.java
@@ -57,7 +57,6 @@ public class ClientPlayerPlaceBlockPacket implements Packet {
 		return this.cursorZ;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.position = NetUtil.readPosition(in);
 		this.face = MagicValues.key(Face.class, in.readUnsignedByte());
@@ -67,7 +66,6 @@ public class ClientPlayerPlaceBlockPacket implements Packet {
 		this.cursorZ = in.readByte() / 16f;
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetUtil.writePosition(out, this.position);
 		out.writeByte(MagicValues.value(Integer.class, this.face));
@@ -77,7 +75,6 @@ public class ClientPlayerPlaceBlockPacket implements Packet {
 		out.writeByte((int) (this.cursorZ * 16));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerStatePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientPlayerStatePacket.java
@@ -40,21 +40,18 @@ public class ClientPlayerStatePacket implements Packet {
 		return this.jumpBoost;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.state = MagicValues.key(PlayerState.class, in.readUnsignedByte());
 		this.jumpBoost = in.readVarInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.state));
 		out.writeVarInt(this.jumpBoost);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientSpectatePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientSpectatePacket.java
@@ -22,17 +22,14 @@ public class ClientSpectatePacket implements Packet {
 		return this.target;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.target = in.readUUID();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeUUID(this.target);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientSteerVehiclePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientSteerVehiclePacket.java
@@ -40,7 +40,6 @@ public class ClientSteerVehiclePacket implements Packet {
 		return this.dismount;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.sideways = in.readFloat();
 		this.forward = in.readFloat();
@@ -49,7 +48,6 @@ public class ClientSteerVehiclePacket implements Packet {
 		this.dismount = (flags & 2) > 0;
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeFloat(this.sideways);
 		out.writeFloat(this.forward);
@@ -65,7 +63,6 @@ public class ClientSteerVehiclePacket implements Packet {
 		out.writeByte(flags);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientSwingArmPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/player/ClientSwingArmPacket.java
@@ -11,15 +11,12 @@ public class ClientSwingArmPacket implements Packet {
 	public ClientSwingArmPacket() {
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientCloseWindowPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientCloseWindowPacket.java
@@ -22,17 +22,14 @@ public class ClientCloseWindowPacket implements Packet {
 		return this.windowId;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readByte();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientConfirmTransactionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientConfirmTransactionPacket.java
@@ -34,21 +34,18 @@ public class ClientConfirmTransactionPacket implements Packet {
 		return this.accepted;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readByte();
 		this.actionId = in.readShort();
 		this.accepted = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 		out.writeShort(this.actionId);
 		out.writeBoolean(this.accepted);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientCreativeInventoryActionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientCreativeInventoryActionPacket.java
@@ -30,19 +30,16 @@ public class ClientCreativeInventoryActionPacket implements Packet {
 		return this.clicked;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.slot = in.readShort();
 		this.clicked = NetUtil.readItem(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeShort(this.slot);
 		NetUtil.writeItem(out, this.clicked);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientEnchantItemPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientEnchantItemPacket.java
@@ -28,19 +28,16 @@ public class ClientEnchantItemPacket implements Packet {
 		return this.enchantment;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readByte();
 		this.enchantment = in.readByte();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 		out.writeByte(this.enchantment);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientWindowActionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/window/ClientWindowActionPacket.java
@@ -56,7 +56,6 @@ public class ClientWindowActionPacket implements Packet {
 		return this.param;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readByte();
 		this.slot = in.readShort();
@@ -81,7 +80,6 @@ public class ClientWindowActionPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 		out.writeShort(this.slot);
@@ -108,7 +106,6 @@ public class ClientWindowActionPacket implements Packet {
 		NetUtil.writeItem(out, this.clicked);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/world/ClientUpdateSignPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/client/world/ClientUpdateSignPacket.java
@@ -34,7 +34,6 @@ public class ClientUpdateSignPacket implements Packet {
 		return this.lines;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.position = NetUtil.readPosition(in);
 		this.lines = new String[4];
@@ -43,7 +42,6 @@ public class ClientUpdateSignPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetUtil.writePosition(out, this.position);
 		for(String line : this.lines) {
@@ -51,7 +49,6 @@ public class ClientUpdateSignPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerChatPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerChatPacket.java
@@ -43,19 +43,16 @@ public class ServerChatPacket implements Packet {
 		return this.type;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.message = Message.fromString(in.readString());
 		this.type = MagicValues.key(MessageType.class, in.readByte());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.message.toJsonString());
 		out.writeByte(MagicValues.value(Integer.class, this.type));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerCombatPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerCombatPacket.java
@@ -53,7 +53,6 @@ public class ServerCombatPacket implements Packet {
 		return this.message;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.state = MagicValues.key(CombatState.class, in.readVarInt());
 		if(this.state == CombatState.END_COMBAT) {
@@ -66,7 +65,6 @@ public class ServerCombatPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(MagicValues.value(Integer.class, this.state));
 		if(this.state == CombatState.END_COMBAT) {
@@ -79,7 +77,6 @@ public class ServerCombatPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerDifficultyPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerDifficultyPacket.java
@@ -24,17 +24,14 @@ public class ServerDifficultyPacket implements Packet {
 		return this.difficulty;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.difficulty = MagicValues.key(Difficulty.class, in.readUnsignedByte());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(MagicValues.value(Integer.class, this.difficulty));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerDisconnectPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerDisconnectPacket.java
@@ -27,17 +27,14 @@ public class ServerDisconnectPacket implements Packet {
 		return this.message;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.message = Message.fromString(in.readString());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.message.toJsonString());
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
@@ -68,7 +68,6 @@ public class ServerJoinGamePacket implements Packet {
 		return this.reducedDebugInfo;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readInt();
 		int gamemode = in.readUnsignedByte();
@@ -82,7 +81,6 @@ public class ServerJoinGamePacket implements Packet {
 		this.reducedDebugInfo = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeInt(this.entityId);
 		int gamemode = MagicValues.value(Integer.class, this.gamemode);
@@ -98,7 +96,6 @@ public class ServerJoinGamePacket implements Packet {
 		out.writeBoolean(this.reducedDebugInfo);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerKeepAlivePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerKeepAlivePacket.java
@@ -22,17 +22,14 @@ public class ServerKeepAlivePacket implements Packet {
 		return this.id;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.id = in.readVarInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.id);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerPlayerListDataPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerPlayerListDataPacket.java
@@ -28,19 +28,16 @@ public class ServerPlayerListDataPacket implements Packet {
 		return this.footer;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.header = Message.fromString(in.readString());
 		this.footer = Message.fromString(in.readString());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.header.toJsonString());
 		out.writeString(this.footer.toJsonString());
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerPlayerListEntryPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerPlayerListEntryPacket.java
@@ -35,7 +35,6 @@ public class ServerPlayerListEntryPacket implements Packet {
 		return this.entries;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.action = MagicValues.key(PlayerListEntryAction.class, in.readVarInt());
 		this.entries = new PlayerListEntry[in.readVarInt()];
@@ -96,7 +95,6 @@ public class ServerPlayerListEntryPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(MagicValues.value(Integer.class, this.action));
 		out.writeVarInt(this.entries.length);
@@ -142,7 +140,6 @@ public class ServerPlayerListEntryPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerPluginMessagePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerPluginMessagePacket.java
@@ -28,19 +28,16 @@ public class ServerPluginMessagePacket implements Packet {
 		return this.data;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.channel = in.readString();
 		this.data = in.readBytes(in.available());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.channel);
 		out.writeBytes(this.data);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerResourcePackSendPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerResourcePackSendPacket.java
@@ -27,19 +27,16 @@ public class ServerResourcePackSendPacket implements Packet {
 		return this.hash;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.url = in.readString();
 		this.hash = in.readString();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.url);
 		out.writeString(this.hash);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
@@ -44,7 +44,6 @@ public class ServerRespawnPacket implements Packet {
 		return this.worldType;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.dimension = in.readInt();
 		this.difficulty = MagicValues.key(Difficulty.class, in.readUnsignedByte());
@@ -52,7 +51,6 @@ public class ServerRespawnPacket implements Packet {
 		this.worldType = MagicValues.key(WorldType.class, in.readString().toLowerCase());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeInt(this.dimension);
 		out.writeByte(MagicValues.value(Integer.class, this.difficulty));
@@ -60,7 +58,6 @@ public class ServerRespawnPacket implements Packet {
 		out.writeString(MagicValues.value(String.class, this.worldType));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerSetCompressionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerSetCompressionPacket.java
@@ -21,17 +21,14 @@ public class ServerSetCompressionPacket implements Packet {
 		return this.threshold;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.threshold = in.readVarInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.threshold);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerStatisticsPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerStatisticsPacket.java
@@ -31,7 +31,6 @@ public class ServerStatisticsPacket implements Packet {
 		return this.statistics;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		int length = in.readVarInt();
 		for(int index = 0; index < length; index++) {
@@ -55,7 +54,6 @@ public class ServerStatisticsPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.statistics.size());
 		for(Statistic statistic : this.statistics.keySet()) {
@@ -79,7 +77,6 @@ public class ServerStatisticsPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerSwitchCameraPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerSwitchCameraPacket.java
@@ -22,17 +22,14 @@ public class ServerSwitchCameraPacket implements Packet {
 		return this.cameraEntityId;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.cameraEntityId = in.readVarInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.cameraEntityId);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerTabCompletePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerTabCompletePacket.java
@@ -22,7 +22,6 @@ public class ServerTabCompletePacket implements Packet {
 		return this.matches;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.matches = new String[in.readVarInt()];
 		for(int index = 0; index < this.matches.length; index++) {
@@ -30,7 +29,6 @@ public class ServerTabCompletePacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.matches.length);
 		for(String match : this.matches) {
@@ -38,7 +36,6 @@ public class ServerTabCompletePacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerTitlePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/ServerTitlePacket.java
@@ -77,7 +77,6 @@ public class ServerTitlePacket implements Packet {
 		return this.fadeOut;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.action = MagicValues.key(TitleAction.class, in.readVarInt());
 		switch(this.action) {
@@ -99,7 +98,6 @@ public class ServerTitlePacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(MagicValues.value(Integer.class, this.action));
 		switch(this.action) {
@@ -121,7 +119,6 @@ public class ServerTitlePacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerAnimationPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerAnimationPacket.java
@@ -30,19 +30,16 @@ public class ServerAnimationPacket implements Packet {
 		return this.animation;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.animation = MagicValues.key(Animation.class, in.readByte());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.animation));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerCollectItemPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerCollectItemPacket.java
@@ -28,19 +28,16 @@ public class ServerCollectItemPacket implements Packet {
 		return this.collectorEntityId;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.collectedEntityId = in.readVarInt();
 		this.collectorEntityId = in.readVarInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.collectedEntityId);
 		out.writeVarInt(this.collectorEntityId);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerDestroyEntitiesPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerDestroyEntitiesPacket.java
@@ -22,7 +22,6 @@ public class ServerDestroyEntitiesPacket implements Packet {
 		return this.entityIds;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityIds = new int[in.readVarInt()];
 		for(int index = 0; index < this.entityIds.length; index++) {
@@ -30,7 +29,6 @@ public class ServerDestroyEntitiesPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityIds.length);
 		for(int entityId : this.entityIds) {
@@ -38,7 +36,6 @@ public class ServerDestroyEntitiesPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityAttachPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityAttachPacket.java
@@ -34,21 +34,18 @@ public class ServerEntityAttachPacket implements Packet {
 		return this.leash;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readInt();
 		this.attachedToId = in.readInt();
 		this.leash = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeInt(this.entityId);
 		out.writeInt(this.attachedToId);
 		out.writeBoolean(this.leash);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityEffectPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityEffectPacket.java
@@ -48,7 +48,6 @@ public class ServerEntityEffectPacket implements Packet {
 		return this.hideParticles;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.effect = MagicValues.key(Effect.class, in.readByte());
@@ -57,7 +56,6 @@ public class ServerEntityEffectPacket implements Packet {
 		this.hideParticles = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.effect));
@@ -66,7 +64,6 @@ public class ServerEntityEffectPacket implements Packet {
 		out.writeBoolean(this.hideParticles);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityEquipmentPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityEquipmentPacket.java
@@ -36,21 +36,18 @@ public class ServerEntityEquipmentPacket implements Packet {
 		return this.item;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.slot = in.readShort();
 		this.item = NetUtil.readItem(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeShort(this.slot);
 		NetUtil.writeItem(out, this.item);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityHeadLookPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityHeadLookPacket.java
@@ -28,19 +28,16 @@ public class ServerEntityHeadLookPacket implements Packet {
 		return this.headYaw;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.headYaw = in.readByte() * 360 / 256f;
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeByte((byte) (this.headYaw * 256 / 360));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityMetadataPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityMetadataPacket.java
@@ -30,19 +30,16 @@ public class ServerEntityMetadataPacket implements Packet {
 		return this.metadata;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.metadata = NetUtil.readEntityMetadata(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		NetUtil.writeEntityMetadata(out, this.metadata);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityMovementPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityMovementPacket.java
@@ -55,7 +55,6 @@ public class ServerEntityMovementPacket implements Packet {
 		return this.onGround;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		if(this.pos) {
@@ -72,7 +71,6 @@ public class ServerEntityMovementPacket implements Packet {
 		this.onGround = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		if(this.pos) {
@@ -89,7 +87,6 @@ public class ServerEntityMovementPacket implements Packet {
 		out.writeBoolean(this.onGround);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityNBTUpdatePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityNBTUpdatePacket.java
@@ -29,19 +29,16 @@ public class ServerEntityNBTUpdatePacket implements Packet {
 		return this.tag;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.tag = NetUtil.readNBT(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		NetUtil.writeNBT(out, this.tag);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityPropertiesPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityPropertiesPacket.java
@@ -35,7 +35,6 @@ public class ServerEntityPropertiesPacket implements Packet {
 		return this.attributes;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.attributes = new ArrayList<Attribute>();
@@ -53,7 +52,6 @@ public class ServerEntityPropertiesPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeInt(this.attributes.size());
@@ -69,7 +67,6 @@ public class ServerEntityPropertiesPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityRemoveEffectPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityRemoveEffectPacket.java
@@ -30,19 +30,16 @@ public class ServerEntityRemoveEffectPacket implements Packet {
 		return this.effect;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.effect = MagicValues.key(Effect.class, in.readByte());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.effect));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityStatusPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityStatusPacket.java
@@ -30,19 +30,16 @@ public class ServerEntityStatusPacket implements Packet {
 		return this.status;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readInt();
 		this.status = MagicValues.key(EntityStatus.class, in.readByte());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.status));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityTeleportPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityTeleportPacket.java
@@ -58,7 +58,6 @@ public class ServerEntityTeleportPacket implements Packet {
 		return this.onGround;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.x = in.readInt() / 32D;
@@ -69,7 +68,6 @@ public class ServerEntityTeleportPacket implements Packet {
 		this.onGround = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeInt((int) (this.x * 32));
@@ -80,7 +78,6 @@ public class ServerEntityTeleportPacket implements Packet {
 		out.writeBoolean(this.onGround);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityVelocityPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/ServerEntityVelocityPacket.java
@@ -40,7 +40,6 @@ public class ServerEntityVelocityPacket implements Packet {
 		return this.motZ;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.motX = in.readShort() / 8000D;
@@ -48,7 +47,6 @@ public class ServerEntityVelocityPacket implements Packet {
 		this.motZ = in.readShort() / 8000D;
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeShort((int) (this.motX * 8000));
@@ -56,7 +54,6 @@ public class ServerEntityVelocityPacket implements Packet {
 		out.writeShort((int) (this.motZ * 8000));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerChangeHeldItemPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerChangeHeldItemPacket.java
@@ -22,17 +22,14 @@ public class ServerChangeHeldItemPacket implements Packet {
 		return this.slot;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.slot = in.readByte();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.slot);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerPlayerAbilitiesPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerPlayerAbilitiesPacket.java
@@ -52,7 +52,6 @@ public class ServerPlayerAbilitiesPacket implements Packet {
 		return this.walkSpeed;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		byte flags = in.readByte();
 		this.invincible = (flags & 1) > 0;
@@ -63,7 +62,6 @@ public class ServerPlayerAbilitiesPacket implements Packet {
 		this.walkSpeed = in.readFloat();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		byte flags = 0;
 		if(this.invincible) {
@@ -87,7 +85,6 @@ public class ServerPlayerAbilitiesPacket implements Packet {
 		out.writeFloat(this.walkSpeed);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerPlayerPositionRotationPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerPlayerPositionRotationPacket.java
@@ -61,7 +61,6 @@ public class ServerPlayerPositionRotationPacket implements Packet {
 		return this.relative;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.x = in.readDouble();
 		this.y = in.readDouble();
@@ -78,7 +77,6 @@ public class ServerPlayerPositionRotationPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeDouble(this.x);
 		out.writeDouble(this.y);
@@ -93,7 +91,6 @@ public class ServerPlayerPositionRotationPacket implements Packet {
 		out.writeByte(flags);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerPlayerUseBedPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerPlayerUseBedPacket.java
@@ -30,19 +30,16 @@ public class ServerPlayerUseBedPacket implements Packet {
 		return this.position;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.position = NetUtil.readPosition(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		NetUtil.writePosition(out, this.position);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerSetExperiencePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerSetExperiencePacket.java
@@ -34,21 +34,18 @@ public class ServerSetExperiencePacket implements Packet {
 		return this.totalExperience;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.experience = in.readFloat();
 		this.level = in.readVarInt();
 		this.totalExperience = in.readVarInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeFloat(this.experience);
 		out.writeVarInt(this.level);
 		out.writeVarInt(this.totalExperience);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerUpdateHealthPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/player/ServerUpdateHealthPacket.java
@@ -34,21 +34,18 @@ public class ServerUpdateHealthPacket implements Packet {
 		return this.saturation;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.health = in.readFloat();
 		this.food = in.readVarInt();
 		this.saturation = in.readFloat();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeFloat(this.health);
 		out.writeVarInt(this.food);
 		out.writeFloat(this.saturation);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnExpOrbPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnExpOrbPacket.java
@@ -46,7 +46,6 @@ public class ServerSpawnExpOrbPacket implements Packet {
 		return this.exp;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.x = in.readInt() / 32D;
@@ -55,7 +54,6 @@ public class ServerSpawnExpOrbPacket implements Packet {
 		this.exp = in.readShort();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeInt((int) (this.x * 32));
@@ -64,7 +62,6 @@ public class ServerSpawnExpOrbPacket implements Packet {
 		out.writeShort(this.exp);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnGlobalEntityPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnGlobalEntityPacket.java
@@ -48,7 +48,6 @@ public class ServerSpawnGlobalEntityPacket implements Packet {
 		return this.z;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.type = MagicValues.key(GlobalEntityType.class, in.readByte());
@@ -57,7 +56,6 @@ public class ServerSpawnGlobalEntityPacket implements Packet {
 		this.z = in.readInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.type));
@@ -66,7 +64,6 @@ public class ServerSpawnGlobalEntityPacket implements Packet {
 		out.writeInt(this.z);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnMobPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnMobPacket.java
@@ -92,7 +92,6 @@ public class ServerSpawnMobPacket implements Packet {
 		return this.metadata;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.type = MagicValues.key(MobType.class, in.readByte());
@@ -108,7 +107,6 @@ public class ServerSpawnMobPacket implements Packet {
 		this.metadata = NetUtil.readEntityMetadata(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.type));
@@ -124,7 +122,6 @@ public class ServerSpawnMobPacket implements Packet {
 		NetUtil.writeEntityMetadata(out, this.metadata);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnObjectPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnObjectPacket.java
@@ -97,7 +97,6 @@ public class ServerSpawnObjectPacket implements Packet {
 		return this.motZ;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.type = MagicValues.key(ObjectType.class, in.readByte());
@@ -129,7 +128,6 @@ public class ServerSpawnObjectPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeByte(MagicValues.value(Integer.class, this.type));
@@ -163,7 +161,6 @@ public class ServerSpawnObjectPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPaintingPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPaintingPacket.java
@@ -45,7 +45,6 @@ public class ServerSpawnPaintingPacket implements Packet {
 		return this.direction;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.art = MagicValues.key(Art.class, in.readString());
@@ -53,7 +52,6 @@ public class ServerSpawnPaintingPacket implements Packet {
 		this.direction = MagicValues.key(HangingDirection.class, in.readUnsignedByte());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeString(MagicValues.value(String.class, this.art));
@@ -61,7 +59,6 @@ public class ServerSpawnPaintingPacket implements Packet {
 		out.writeByte(MagicValues.value(Integer.class, this.direction));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPlayerPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPlayerPacket.java
@@ -73,7 +73,6 @@ public class ServerSpawnPlayerPacket implements Packet {
 		return this.metadata;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entityId = in.readVarInt();
 		this.uuid = in.readUUID();
@@ -86,7 +85,6 @@ public class ServerSpawnPlayerPacket implements Packet {
 		this.metadata = NetUtil.readEntityMetadata(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.entityId);
 		out.writeUUID(this.uuid);
@@ -99,7 +97,6 @@ public class ServerSpawnPlayerPacket implements Packet {
 		NetUtil.writeEntityMetadata(out, this.metadata);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerDisplayScoreboardPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerDisplayScoreboardPacket.java
@@ -30,19 +30,16 @@ public class ServerDisplayScoreboardPacket implements Packet {
 		return this.name;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.position = MagicValues.key(ScoreboardPosition.class, in.readByte());
 		this.name = in.readString();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(MagicValues.value(Integer.class, this.position));
 		out.writeString(this.name);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerScoreboardObjectivePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerScoreboardObjectivePacket.java
@@ -52,7 +52,6 @@ public class ServerScoreboardObjectivePacket implements Packet {
 		return this.type;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.name = in.readString();
 		this.action = MagicValues.key(ObjectiveAction.class, in.readByte());
@@ -62,7 +61,6 @@ public class ServerScoreboardObjectivePacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.name);
 		out.writeByte(MagicValues.value(Integer.class, this.action));
@@ -72,7 +70,6 @@ public class ServerScoreboardObjectivePacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerTeamPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerTeamPacket.java
@@ -107,7 +107,6 @@ public class ServerTeamPacket implements Packet {
 		return this.players;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.name = in.readString();
 		this.action = MagicValues.key(TeamAction.class, in.readByte());
@@ -130,7 +129,6 @@ public class ServerTeamPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.name);
 		out.writeByte(MagicValues.value(Integer.class, this.action));
@@ -160,7 +158,6 @@ public class ServerTeamPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerUpdateScorePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/scoreboard/ServerUpdateScorePacket.java
@@ -48,7 +48,6 @@ public class ServerUpdateScorePacket implements Packet {
 		return this.value;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.entry = in.readString();
 		this.action = MagicValues.key(ScoreboardAction.class, in.readByte());
@@ -57,8 +56,6 @@ public class ServerUpdateScorePacket implements Packet {
 			this.value = in.readVarInt();
 		}
 	}
-
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.entry);
 		out.writeByte(MagicValues.value(Integer.class, this.action));
@@ -68,7 +65,6 @@ public class ServerUpdateScorePacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerCloseWindowPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerCloseWindowPacket.java
@@ -22,17 +22,14 @@ public class ServerCloseWindowPacket implements Packet {
 		return this.windowId;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readUnsignedByte();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerConfirmTransactionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerConfirmTransactionPacket.java
@@ -34,21 +34,18 @@ public class ServerConfirmTransactionPacket implements Packet {
 		return this.accepted;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readUnsignedByte();
 		this.actionId = in.readShort();
 		this.accepted = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 		out.writeShort(this.actionId);
 		out.writeBoolean(this.accepted);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerOpenWindowPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerOpenWindowPacket.java
@@ -52,7 +52,6 @@ public class ServerOpenWindowPacket implements Packet {
 		return this.ownerEntityId;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readUnsignedByte();
 		this.type = MagicValues.key(WindowType.class, in.readString());
@@ -63,7 +62,6 @@ public class ServerOpenWindowPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 		out.writeString(MagicValues.value(String.class, this.type));
@@ -74,7 +72,6 @@ public class ServerOpenWindowPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerSetSlotPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerSetSlotPacket.java
@@ -36,21 +36,18 @@ public class ServerSetSlotPacket implements Packet {
 		return this.item;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readUnsignedByte();
 		this.slot = in.readShort();
 		this.item = NetUtil.readItem(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 		out.writeShort(this.slot);
 		NetUtil.writeItem(out, this.item);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerWindowItemsPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerWindowItemsPacket.java
@@ -30,7 +30,6 @@ public class ServerWindowItemsPacket implements Packet {
 		return this.items;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readUnsignedByte();
 		this.items = new ItemStack[in.readShort()];
@@ -39,7 +38,6 @@ public class ServerWindowItemsPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 		out.writeShort(this.items.length);
@@ -48,7 +46,6 @@ public class ServerWindowItemsPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerWindowPropertyPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/window/ServerWindowPropertyPacket.java
@@ -46,21 +46,18 @@ public class ServerWindowPropertyPacket implements Packet {
 		return this.value;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.windowId = in.readUnsignedByte();
 		this.property = in.readShort();
 		this.value = in.readShort();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(this.windowId);
 		out.writeShort(this.property);
 		out.writeShort(this.value);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerBlockBreakAnimPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerBlockBreakAnimPacket.java
@@ -38,7 +38,6 @@ public class ServerBlockBreakAnimPacket implements Packet {
 		return this.stage;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.breakerEntityId = in.readVarInt();
 		this.position = NetUtil.readPosition(in);
@@ -48,14 +47,12 @@ public class ServerBlockBreakAnimPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.breakerEntityId);
 		NetUtil.writePosition(out, this.position);
 		out.writeByte(MagicValues.value(Integer.class, this.stage));
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerBlockChangePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerBlockChangePacket.java
@@ -24,18 +24,15 @@ public class ServerBlockChangePacket implements Packet {
 		return this.record;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.record = new BlockChangeRecord(NetUtil.readPosition(in), in.readVarInt());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetUtil.writePosition(out, this.record.getPosition());
 		out.writeVarInt(this.record.getBlock());
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerBlockValuePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerBlockValuePacket.java
@@ -52,7 +52,6 @@ public class ServerBlockValuePacket implements Packet {
 		return this.blockId;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.position = NetUtil.readPosition(in);
 		int type = in.readUnsignedByte();
@@ -84,7 +83,6 @@ public class ServerBlockValuePacket implements Packet {
 		this.blockId = in.readVarInt() & 4095;
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetUtil.writePosition(out, this.position);
 		int type = 0;
@@ -118,7 +116,6 @@ public class ServerBlockValuePacket implements Packet {
 		out.writeVarInt(this.blockId & 4095);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerChunkDataPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerChunkDataPacket.java
@@ -99,7 +99,6 @@ public class ServerChunkDataPacket implements Packet {
 		return this.biomeData != null;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.x = in.readInt();
 		this.z = in.readInt();
@@ -111,7 +110,6 @@ public class ServerChunkDataPacket implements Packet {
 		this.biomeData = chunkData.getBiomes();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetworkChunkData data = NetUtil.chunksToData(new ParsedChunkData(this.chunks, this.biomeData));
 		out.writeInt(this.x);
@@ -122,7 +120,6 @@ public class ServerChunkDataPacket implements Packet {
 		out.writeBytes(data.getData(), data.getData().length);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerExplosionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerExplosionPacket.java
@@ -67,7 +67,6 @@ public class ServerExplosionPacket implements Packet {
 		return this.pushZ;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.x = in.readFloat();
 		this.y = in.readFloat();
@@ -84,7 +83,6 @@ public class ServerExplosionPacket implements Packet {
 		this.pushZ = in.readFloat();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeFloat(this.x);
 		out.writeFloat(this.y);
@@ -102,7 +100,6 @@ public class ServerExplosionPacket implements Packet {
 		out.writeFloat(this.pushZ);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerMapDataPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerMapDataPacket.java
@@ -46,7 +46,6 @@ public class ServerMapDataPacket implements Packet {
 		return this.data;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.mapId = in.readVarInt();
 		this.scale = in.readByte();
@@ -70,7 +69,6 @@ public class ServerMapDataPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.mapId);
 		out.writeByte(this.scale);
@@ -94,7 +92,6 @@ public class ServerMapDataPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerMultiBlockChangePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerMultiBlockChangePacket.java
@@ -28,7 +28,6 @@ public class ServerMultiBlockChangePacket implements Packet {
 		return this.records;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		int chunkX = in.readInt();
 		int chunkZ = in.readInt();
@@ -43,7 +42,6 @@ public class ServerMultiBlockChangePacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		int chunkX = this.records[0].getPosition().getX() >> 4;
 		int chunkZ = this.records[0].getPosition().getZ() >> 4;
@@ -56,7 +54,6 @@ public class ServerMultiBlockChangePacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerMultiChunkDataPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerMultiChunkDataPacket.java
@@ -79,7 +79,6 @@ public class ServerMultiChunkDataPacket implements Packet {
 		return this.biomeData[column];
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		boolean skylight = in.readBoolean();
 		int columns = in.readVarInt();
@@ -106,7 +105,6 @@ public class ServerMultiChunkDataPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		boolean skylight = false;
 		NetworkChunkData data[] = new NetworkChunkData[this.chunks.length];
@@ -130,7 +128,6 @@ public class ServerMultiChunkDataPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerNotifyClientPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerNotifyClientPacket.java
@@ -31,7 +31,6 @@ public class ServerNotifyClientPacket implements Packet {
 		return this.value;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.notification = MagicValues.key(ClientNotification.class, in.readUnsignedByte());
 		float value = in.readFloat();
@@ -46,7 +45,6 @@ public class ServerNotifyClientPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeByte(MagicValues.value(Integer.class, this.notification));
 		float value = 0;
@@ -69,7 +67,6 @@ public class ServerNotifyClientPacket implements Packet {
 		out.writeFloat(value);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerOpenTileEntityEditorPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerOpenTileEntityEditorPacket.java
@@ -24,17 +24,14 @@ public class ServerOpenTileEntityEditorPacket implements Packet {
 		return this.position;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.position = NetUtil.readPosition(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetUtil.writePosition(out, this.position);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerPlayEffectPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerPlayEffectPacket.java
@@ -48,7 +48,6 @@ public class ServerPlayEffectPacket implements Packet {
 		return this.broadcast;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		int id = in.readInt();
 		if(id >= 2000) {
@@ -74,7 +73,6 @@ public class ServerPlayEffectPacket implements Packet {
 		this.broadcast = in.readBoolean();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		int id = 0;
 		if(this.effect instanceof ParticleEffect) {
@@ -102,7 +100,6 @@ public class ServerPlayEffectPacket implements Packet {
 		out.writeBoolean(this.broadcast);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerPlaySoundPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerPlaySoundPacket.java
@@ -56,7 +56,6 @@ public class ServerPlaySoundPacket implements Packet {
 		return this.pitch;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		String value = in.readString();
 		this.sound = MagicValues.key(GenericSound.class, value);
@@ -71,7 +70,6 @@ public class ServerPlaySoundPacket implements Packet {
 		this.pitch = in.readUnsignedByte() / 63f;
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		String value = "";
 		if(this.sound instanceof CustomSound) {
@@ -97,7 +95,6 @@ public class ServerPlaySoundPacket implements Packet {
 		out.writeByte(pitch);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerSpawnParticlePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerSpawnParticlePacket.java
@@ -86,7 +86,6 @@ public class ServerSpawnParticlePacket implements Packet {
 		return this.data;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.particle = MagicValues.key(Particle.class, in.readInt());
 		this.longDistance = in.readBoolean();
@@ -104,7 +103,6 @@ public class ServerSpawnParticlePacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeInt(MagicValues.value(Integer.class, this.particle));
 		out.writeBoolean(this.longDistance);
@@ -121,7 +119,6 @@ public class ServerSpawnParticlePacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerSpawnPositionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerSpawnPositionPacket.java
@@ -24,17 +24,14 @@ public class ServerSpawnPositionPacket implements Packet {
 		return this.position;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.position = NetUtil.readPosition(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetUtil.writePosition(out, this.position);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerUpdateSignPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerUpdateSignPacket.java
@@ -38,7 +38,6 @@ public class ServerUpdateSignPacket implements Packet {
 		return this.lines;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.position = NetUtil.readPosition(in);
 		this.lines = new Message[4];
@@ -47,7 +46,6 @@ public class ServerUpdateSignPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetUtil.writePosition(out, this.position);
 		for(Message line : this.lines) {
@@ -55,7 +53,6 @@ public class ServerUpdateSignPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerUpdateTileEntityPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerUpdateTileEntityPacket.java
@@ -39,21 +39,18 @@ public class ServerUpdateTileEntityPacket implements Packet {
 		return this.nbt;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.position = NetUtil.readPosition(in);
 		this.type = MagicValues.key(UpdatedTileType.class, in.readUnsignedByte());
 		this.nbt = NetUtil.readNBT(in);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		NetUtil.writePosition(out, this.position);
 		out.writeByte(MagicValues.value(Integer.class, this.type));
 		NetUtil.writeNBT(out, this.nbt);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerUpdateTimePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerUpdateTimePacket.java
@@ -28,19 +28,16 @@ public class ServerUpdateTimePacket implements Packet {
 		return this.time;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.age = in.readLong();
 		this.time = in.readLong();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeLong(this.age);
 		out.writeLong(this.time);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerWorldBorderPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/ingame/server/world/ServerWorldBorderPacket.java
@@ -111,7 +111,6 @@ public class ServerWorldBorderPacket implements Packet {
 		return this.warningBlocks;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.action = MagicValues.key(WorldBorderAction.class, in.readVarInt());
 		if(this.action == WorldBorderAction.SET_SIZE) {
@@ -139,7 +138,6 @@ public class ServerWorldBorderPacket implements Packet {
 		}
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(MagicValues.value(Integer.class, this.action));
 		if(this.action == WorldBorderAction.SET_SIZE) {
@@ -167,7 +165,6 @@ public class ServerWorldBorderPacket implements Packet {
 		}
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/login/client/EncryptionResponsePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/login/client/EncryptionResponsePacket.java
@@ -32,13 +32,11 @@ public class EncryptionResponsePacket implements Packet {
 		return CryptUtil.decryptData(privateKey, this.verifyToken);
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.sharedKey = in.readBytes(in.readVarInt());
 		this.verifyToken = in.readBytes(in.readVarInt());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.sharedKey.length);
 		out.writeBytes(this.sharedKey);
@@ -46,7 +44,6 @@ public class EncryptionResponsePacket implements Packet {
 		out.writeBytes(this.verifyToken);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/login/client/LoginStartPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/login/client/LoginStartPacket.java
@@ -22,17 +22,14 @@ public class LoginStartPacket implements Packet {
 		return this.username;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.username = in.readString();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.username);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/login/server/EncryptionRequestPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/login/server/EncryptionRequestPacket.java
@@ -36,14 +36,12 @@ public class EncryptionRequestPacket implements Packet {
 		return this.verifyToken;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.serverId = in.readString();
 		this.publicKey = CryptUtil.decodePublicKey(in.readBytes(in.readVarInt()));
 		this.verifyToken = in.readBytes(in.readVarInt());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.serverId);
 		byte encoded[] = this.publicKey.getEncoded();
@@ -53,7 +51,6 @@ public class EncryptionRequestPacket implements Packet {
 		out.writeBytes(this.verifyToken);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/login/server/LoginDisconnectPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/login/server/LoginDisconnectPacket.java
@@ -27,17 +27,14 @@ public class LoginDisconnectPacket implements Packet {
 		return this.message;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.message = Message.fromString(in.readString());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.message.toJsonString());
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/login/server/LoginSetCompressionPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/login/server/LoginSetCompressionPacket.java
@@ -21,17 +21,14 @@ public class LoginSetCompressionPacket implements Packet {
 		return this.threshold;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.threshold = in.readVarInt();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeVarInt(this.threshold);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/login/server/LoginSuccessPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/login/server/LoginSuccessPacket.java
@@ -23,18 +23,15 @@ public class LoginSuccessPacket implements Packet {
 		return this.profile;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.profile = new GameProfile(in.readString(), in.readString());
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeString(this.profile.getIdAsString());
 		out.writeString(this.profile.getName());
 	}
 
-	@Override
 	public boolean isPriority() {
 		return true;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/status/client/StatusPingPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/status/client/StatusPingPacket.java
@@ -22,17 +22,14 @@ public class StatusPingPacket implements Packet {
 		return this.time;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.time = in.readLong();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeLong(this.time);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/status/client/StatusQueryPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/status/client/StatusQueryPacket.java
@@ -11,15 +11,12 @@ public class StatusQueryPacket implements Packet {
 	public StatusQueryPacket() {
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/status/server/StatusPongPacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/status/server/StatusPongPacket.java
@@ -22,17 +22,14 @@ public class StatusPongPacket implements Packet {
 		return this.time;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		this.time = in.readLong();
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		out.writeLong(this.time);
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}

--- a/src/main/java/org/spacehq/mc/protocol/packet/status/server/StatusResponsePacket.java
+++ b/src/main/java/org/spacehq/mc/protocol/packet/status/server/StatusResponsePacket.java
@@ -36,7 +36,6 @@ public class StatusResponsePacket implements Packet {
 		return this.info;
 	}
 
-	@Override
 	public void read(NetInput in) throws IOException {
 		JsonObject obj = new Gson().fromJson(in.readString(), JsonObject.class);
 		JsonObject ver = obj.get("version").getAsJsonObject();
@@ -65,7 +64,6 @@ public class StatusResponsePacket implements Packet {
 		this.info = new ServerStatusInfo(version, players, description, icon);
 	}
 
-	@Override
 	public void write(NetOutput out) throws IOException {
 		JsonObject obj = new JsonObject();
 		JsonObject ver = new JsonObject();
@@ -124,7 +122,6 @@ public class StatusResponsePacket implements Packet {
 		return "data:image/png;base64," + new String(encoded, "UTF-8");
 	}
 
-	@Override
 	public boolean isPriority() {
 		return false;
 	}


### PR DESCRIPTION
In Eclipse, by importing the Maven Project, there are a few errors by implementing the class Packet.

For example by:
- public void read(NetInput in)
- public void write(NetOutput out)
- public boolean isPriority()

These methods are marked with the @Override Annotation, but they only implementing an interface and not a class, so you have to remove the @Override Annotation.
