### PR TITLE
Fix empty text messages failing to parse

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/data/message/Message.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/message/Message.java
@@ -1,9 +1,9 @@
 package org.spacehq.mc.protocol.data.message;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -138,7 +138,7 @@ public abstract class Message implements Cloneable {
 
 	public static Message fromString(String str) {
 		try {
-			return fromJson(new Gson().fromJson(str, JsonObject.class));
+			return fromJson(new JsonParser().parse(str));
 		} catch(Exception e) {
 			return new TextMessage(str);
 		}


### PR DESCRIPTION
## Current situation

Using Gson to parse an empty json text message (that is `""`) returns a `JsonPrimitive` with the empty string as its value. However we currently expect there to be a `JsonObject` which produces a `ClassCastException`. After an exception occurred the input json string is simply returned as a TextMessage leading to messages with `""` instead of an empty content.
(This is probably also the case with not empty string, however I have not seen Minecraft produce any of these. Most of the time these contain formatting/translations or similar)
## How this problem is solved

The straightforward solution would be not to expect a `JsonObject` but a `JsonElement`.
However I've decided to just use the `JsonParser` instead of `Gson` which is as lightweight alternative to the heavy/powerful `Gson` class as we don't need any of the fancy json-to-arbitrary-java-object conversions. 
This not only fixes the bug explained above but also provides a performance improvement over using the `Gson` class (Measurements have been taken quiet some time ago so I can't remember the exact results but it was definitely noticeable when processing gigantic amounts of packets).
