### PR TITLE
Make ServerListener use default ServerInfoBuilder and compression threshold if the flag is not set

### DIFF
--- a/src/main/java/org/spacehq/mc/protocol/data/status/VersionInfo.java
+++ b/src/main/java/org/spacehq/mc/protocol/data/status/VersionInfo.java
@@ -1,6 +1,11 @@
 package org.spacehq.mc.protocol.data.status;
 
+import org.spacehq.mc.protocol.MinecraftConstants;
+
 public class VersionInfo {
+
+    public static final VersionInfo CURRENT = new VersionInfo(MinecraftConstants.GAME_VERSION, MinecraftConstants.PROTOCOL_VERSION);
+
     private String name;
     private int protocol;
 


### PR DESCRIPTION
It will allow developers to create a server without setting any flag.
