### PR TITLE
Update protocol ids for 1.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.spacehq</groupId>
     <artifactId>mcprotocollib</artifactId>
-    <version>1.11-SNAPSHOT</version>
+    <version>1.11.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>MCProtocolLib</name>

--- a/src/main/java/org/spacehq/mc/protocol/MinecraftConstants.java
+++ b/src/main/java/org/spacehq/mc/protocol/MinecraftConstants.java
@@ -2,8 +2,8 @@ package org.spacehq.mc.protocol;
 
 public class MinecraftConstants {
     // General Constants
-    public static final String GAME_VERSION = "1.11";
-    public static final int PROTOCOL_VERSION = 315;
+    public static final String GAME_VERSION = "1.11.2";
+    public static final int PROTOCOL_VERSION = 316;
 
     // General Key Constants
     public static final String PROFILE_KEY = "profile";


### PR DESCRIPTION
According to the protocol documentation on [wiki.vg](http://wiki.vg/Pre-release_protocol). The only changes besides the newer protocol version is some added metadata properties which should already be supported.