### PR TITLE
Fix out of bounds smoke effect data

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerPlayEffectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerPlayEffectPacket.java
@@ -66,7 +66,7 @@ public class ServerPlayEffectPacket implements Packet {
         if(this.effect == SoundEffect.RECORD) {
             this.data = new RecordEffectData(value);
         } else if(this.effect == ParticleEffect.SMOKE) {
-            this.data = MagicValues.key(SmokeEffectData.class, value);
+            this.data = MagicValues.key(SmokeEffectData.class, value % 9);
         } else if(this.effect == ParticleEffect.BREAK_BLOCK) {
             this.data = new BreakBlockEffectData(new BlockState(value & 4095, (value >> 12) & 255));
         } else if(this.effect == ParticleEffect.BREAK_SPLASH_POTION) {


### PR DESCRIPTION
Minecraft allows any value to be sent for the smoke effect data and will simply act as if the value was `value % 9` and for some unknown reason there actually exist servers in the wild that rely on this behavior and send different values (e.g. `32`).

While Minecraft will also accept negative numbers, it will behave strangely and I've never seen those being used in the wild, so this PR doesn't deal with those.