### PR TITLE
Update javadoc plugin so it won't crash on my Mac

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -131,6 +131,7 @@
                 <configuration>
                     <show>public</show>
                     <failOnError>false</failOnError>
+                    <additionalOptions>-html5</additionalOptions>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Before I had this error
`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar (attach-javadocs) on project mcprotocollib: Execution attach-javadocs of goal org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-javadoc-plugin:2.10.4:jar: java.lang.ExceptionInInitializerError: null`