### PR TITLE
Re-add ARMOR_STAND to MobType

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -332,6 +332,7 @@ public class MagicValues {
 
         register(GlobalEntityType.LIGHTNING_BOLT, 1);
 
+        register(MobType.ARMOR_STAND, 1);
         register(MobType.BAT, 3);
         register(MobType.BLAZE, 4);
         register(MobType.CAVE_SPIDER, 6);

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/type/MobType.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/type/MobType.java
@@ -1,6 +1,7 @@
 package com.github.steveice10.mc.protocol.data.game.entity.type;
 
 public enum MobType {
+    ARMOR_STAND,
     BAT,
     BLAZE,
     CAVE_SPIDER,


### PR DESCRIPTION
It probably got lost somewhere in the 1.13 - 1.13.2 updates because it's not an actual mob (i.e. vanilla spawns it via the SpawnObject packet).

Note: Almost any object can be sucessfully spawned via SpawnMob, however a vanilla server never makes use of that (it always uses the more appropriate spawn packets) and I'm not aware of any third-party server which does (except for armor stands, hence this PR).