### PR TITLE
Fix magic value of GlobalEntityType.LIGHTNING_BOLT

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -358,7 +358,7 @@ public class MagicValues {
         register(PositionElement.PITCH, 3);
         register(PositionElement.YAW, 4);
 
-        register(GlobalEntityType.LIGHTNING_BOLT, 99);
+        register(GlobalEntityType.LIGHTNING_BOLT, 1);
 
         register(MobType.AREA_EFFECT_CLOUD, 0);
         register(MobType.ARMOR_STAND, 1);


### PR DESCRIPTION
This got changed during the 1.14 update. Afaict the value was always 1 (I checked vanilla 1.13.2, 1.14 and 1.14.3, not sure about snapshots) and wiki.vg doesn't show any changes either, so I don't know why it was changed to 99.
@Paulomart do you remember where you got that from?