### PR TITLE
Fix MagicValue.key/value being swapped in ServerOpenBookPacket

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerOpenBookPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerOpenBookPacket.java
@@ -25,11 +25,11 @@ public class ServerOpenBookPacket extends MinecraftPacket {
 
     @Override
     public void read(NetInput in) throws IOException {
-        this.hand = MagicValues.value(Hand.class, in.readVarInt());
+        this.hand = MagicValues.key(Hand.class, in.readVarInt());
     }
 
     @Override
     public void write(NetOutput out) throws IOException {
-        out.writeVarInt(MagicValues.key(Integer.class, hand));
+        out.writeVarInt(MagicValues.value(Integer.class, hand));
     }
 }


### PR DESCRIPTION
Fixes the second of the two issues in #474 (second in order of comments, first in order of edited post)