### PR TITLE
ServerTabCompletePacket: tooltip can be of type TranslationMessage

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerTabCompletePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerTabCompletePacket.java
@@ -42,7 +42,7 @@ public class ServerTabCompletePacket implements Packet {
         this.start = in.readVarInt();
         this.length = in.readVarInt();
         this.matches = new String[in.readVarInt()];
-        this.tooltips = new TextMessage[this.matches.length];
+        this.tooltips = new Message[this.matches.length];
         for(int index = 0; index < this.matches.length; index++) {
             this.matches[index] = in.readString();
             if (in.readBoolean()) {


### PR DESCRIPTION
It fixes an ArrayStoreException when a ServerTabCompletePacket is received with some tooltips of type TranslationsMessage.

Steps to reproduce:
1. Connect to a minecraft 1.14.4 vanilla server.
2. Write '/tp '

The client will received ServerTabCompletePacket with translations messages like: 'argument.entity.selector.allPlayers', 'argument.entity.selector.allEntities', etc.