### PR TITLE
the "minecraft:" isn't sent by all servers

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/advancement/Advancement.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/advancement/Advancement.java
@@ -12,12 +12,12 @@ import java.util.List;
 @AllArgsConstructor
 public class Advancement {
     private final @NonNull String id;
-    private final @NonNull String parentId;
+    private final String parentId;
     private final @NonNull List<String> criteria;
     private final @NonNull List<List<String>> requirements;
     private final DisplayData displayData;
 
-    public Advancement(@NonNull String id, @NonNull String parentId, @NonNull List<String> criteria, @NonNull List<List<String>> requirements) {
+    public Advancement(@NonNull String id, String parentId, @NonNull List<String> criteria, @NonNull List<List<String>> requirements) {
         this(id, parentId, criteria, requirements, null);
     }
 

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareRecipesPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareRecipesPacket.java
@@ -34,7 +34,11 @@ public class ServerDeclareRecipesPacket implements Packet {
     public void read(NetInput in) throws IOException {
         this.recipes = new Recipe[in.readVarInt()];
         for(int i = 0; i < this.recipes.length; i++) {
-            RecipeType type = MagicValues.key(RecipeType.class, in.readString());
+            String recipeTypeString = in.readString();
+            if(!recipeTypeString.contains(":")){
+                recipeTypeString = "minecraft:" + recipeTypeString;
+            }
+            RecipeType type = MagicValues.key(RecipeType.class, recipeTypeString);
             String identifier = in.readString();
             RecipeData data = null;
             switch(type) {


### PR DESCRIPTION
Specifically 1.13.2 servers that allow 1.14 clients to join. So it crashes on connecting to server with "java.lang.IllegalArgumentException: Value smelting has no mapping for key class com.github.steveice10.mc.protocol.data.game.recipe.RecipeType" because the mapping is minecraft:smelting