### PR TITLE
Fix missing CommandParser values (Fixes #495) and allow null MapIcon display names

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -1165,6 +1165,7 @@ public class MagicValues {
         register(CommandParser.DIMENSION, "minecraft:dimension");
         register(CommandParser.TIME, "minecraft:time");
         register(CommandParser.NBT_COMPOUND_TAG, "minecraft:nbt_compound_tag");
+        register(CommandParser.NBT_TAG, "minecraft:nbt_tag");
 
         register(SuggestionType.ASK_SERVER, "minecraft:ask_server");
         register(SuggestionType.ALL_RECIPES, "minecraft:all_recipes");

--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -1164,6 +1164,7 @@ public class MagicValues {
         register(CommandParser.ENTITY_SUMMON, "minecraft:entity_summon");
         register(CommandParser.DIMENSION, "minecraft:dimension");
         register(CommandParser.TIME, "minecraft:time");
+        register(CommandParser.NBT_COMPOUND_TAG, "minecraft:nbt_compound_tag");
 
         register(SuggestionType.ASK_SERVER, "minecraft:ask_server");
         register(SuggestionType.ALL_RECIPES, "minecraft:all_recipes");

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/command/CommandParser.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/command/CommandParser.java
@@ -21,6 +21,7 @@ public enum CommandParser {
     MESSAGE,
     NBT,
     NBT_COMPOUND_TAG,
+    NBT_TAG,
     NBT_PATH,
     OBJECTIVE,
     OBJECTIVE_CRITERIA,

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/command/CommandParser.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/command/CommandParser.java
@@ -20,6 +20,7 @@ public enum CommandParser {
     COMPONENT,
     MESSAGE,
     NBT,
+    NBT_COMPOUND_TAG,
     NBT_PATH,
     OBJECTIVE,
     OBJECTIVE_CRITERIA,

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/world/map/MapIcon.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/world/map/MapIcon.java
@@ -12,5 +12,5 @@ public class MapIcon {
     private final int centerZ;
     private final @NonNull MapIconType iconType;
     private final int iconRotation;
-    private final @NonNull Message displayName;
+    private final Message displayName;
 }


### PR DESCRIPTION
This PR does the following:
- Adds the missing `nbt_tag` and `nbt_compound_tag` from the command parser.
- Allows for a MapIcon display name to be null.

Previously before the codebase was lombok-ized, MapIcon display names were allowed to be null in the library, but since then, if there was a null one on the server, the client (through MCProtocolLib) would be kicked for an NPE.