### PR TITLE
Use no color as default color

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/message/ChatColor.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/message/ChatColor.java
@@ -17,7 +17,8 @@ public enum ChatColor {
     LIGHT_PURPLE,
     YELLOW,
     WHITE,
-    RESET;
+    RESET,
+    NONE;
 
     public static ChatColor byName(String name) {
         name = name.toLowerCase();

--- a/src/main/java/com/github/steveice10/mc/protocol/data/message/Message.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/message/Message.java
@@ -166,7 +166,10 @@ public abstract class Message implements Cloneable {
 
     public JsonElement toJson() {
         JsonObject json = new JsonObject();
-        json.addProperty("color", this.style.getColor().toString());
+        if(this.style.hasColor()) {
+            json.addProperty("color", this.style.getColor().toString());
+        }
+
         for(ChatFormat format : this.style.getFormats()) {
             json.addProperty(format.toString(), true);
         }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/message/MessageStyle.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/message/MessageStyle.java
@@ -12,7 +12,7 @@ import java.util.List;
 public class MessageStyle implements Cloneable {
     private static final MessageStyle DEFAULT = new MessageStyle();
 
-    private ChatColor color = ChatColor.WHITE;
+    private ChatColor color = ChatColor.NONE;
     private List<ChatFormat> formats = new ArrayList<ChatFormat>();
     private ClickEvent clickEvent;
     private HoverEvent hoverEvent;
@@ -21,6 +21,10 @@ public class MessageStyle implements Cloneable {
 
     public boolean isDefault() {
         return this.equals(DEFAULT);
+    }
+
+    public boolean hasColor() {
+        return color != ChatColor.NONE;
     }
 
     public MessageStyle setColor(ChatColor color) {


### PR DESCRIPTION
I'm working on a protocol translator with other people and I noticed that the default color is white even when there is no color given. This is fine for most cases, but is a bit strange for things like signs.
You get this:
![](https://media.discordapp.net/attachments/613194828359925800/652543902892687361/unknown.png)
when you expect this:
![image](https://user-images.githubusercontent.com/14874493/70340379-fed45500-1850-11ea-899b-8f71539474ff.png)
I thought about a few ways to fix this, but this was the best way imo. It won't return null, instead it will return ChatColor type NONE.

BTW: Have a look at the @Accessors(chain=true) annotation for classes like MessageStyle