### PR TITLE
START_RAIN and STOP_RAIN is mixed up

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -688,8 +688,8 @@ public class MagicValues {
         register(UpdatedTileType.BEEHIVE, 14);
 
         register(ClientNotification.INVALID_BED, 0);
-        register(ClientNotification.START_RAIN, 2);
-        register(ClientNotification.STOP_RAIN, 1);
+        register(ClientNotification.START_RAIN, 1);
+        register(ClientNotification.STOP_RAIN, 2);
         register(ClientNotification.CHANGE_GAMEMODE, 3);
         register(ClientNotification.ENTER_CREDITS, 4);
         register(ClientNotification.DEMO_MESSAGE, 5);


### PR DESCRIPTION
This breaks GeyserMC, so the Bedrock client thinks it stops raining when it starts, and vice versa.