### PR TITLE
Set proxy to null in example

### DIFF
--- a/example/com/github/steveice10/mc/protocol/test/MinecraftProtocolTest.java
+++ b/example/com/github/steveice10/mc/protocol/test/MinecraftProtocolTest.java
@@ -43,7 +43,7 @@ public class MinecraftProtocolTest {
     private static final boolean VERIFY_USERS = false;
     private static final String HOST = "127.0.0.1";
     private static final int PORT = 25565;
-    private static final Proxy PROXY = Proxy.NO_PROXY;
+    private static final Proxy PROXY = null;
     private static final Proxy AUTH_PROXY = Proxy.NO_PROXY;
     private static final String USERNAME = "Username";
     private static final String PASSWORD = "Password";


### PR DESCRIPTION
Otherwise, it will use deprecated OioSocketChannel instead of non-blocking NioSocketChannel.