### PR TITLE
Add support for Minecraft 1.15.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.github.steveice10</groupId>
     <artifactId>mcprotocollib</artifactId>
-    <version>1.15.1-1-SNAPSHOT</version>
+    <version>1.15.2-1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>MCProtocolLib</name>

--- a/src/main/java/com/github/steveice10/mc/protocol/MinecraftConstants.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/MinecraftConstants.java
@@ -2,8 +2,8 @@ package com.github.steveice10.mc.protocol;
 
 public class MinecraftConstants {
     // General Constants
-    public static final String GAME_VERSION = "1.15.1";
-    public static final int PROTOCOL_VERSION = 575;
+    public static final String GAME_VERSION = "1.15.2";
+    public static final int PROTOCOL_VERSION = 578;
 
     // General Key Constants
     public static final String PROFILE_KEY = "profile";


### PR DESCRIPTION
Adds support for Minecraft 1.15.2. It appears protocol-wise, only the number was bumped.