### PR TITLE
Allow secondTrade in VillagerTrade to be null

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/window/VillagerTrade.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/window/VillagerTrade.java
@@ -9,7 +9,7 @@ import lombok.NonNull;
 @AllArgsConstructor
 public class VillagerTrade {
     private final @NonNull ItemStack firstInput;
-    private final @NonNull ItemStack secondInput;
+    private final ItemStack secondInput;
     private final @NonNull ItemStack output;
     private final boolean tradeDisabled;
     private final int numUses;


### PR DESCRIPTION
This allows the second trade slot in villager trades to be null. Not in all cases will the second input in the villager trade be present.