### PR TITLE
Fix flipped start and stop for rain

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -690,8 +690,8 @@ public class MagicValues {
         register(UpdatedTileType.BEEHIVE, 14);
 
         register(ClientNotification.INVALID_BED, 0);
-        register(ClientNotification.START_RAIN, 1);
-        register(ClientNotification.STOP_RAIN, 2);
+        register(ClientNotification.STOP_RAIN, 1);
+        register(ClientNotification.START_RAIN, 2);
         register(ClientNotification.CHANGE_GAMEMODE, 3);
         register(ClientNotification.ENTER_CREDITS, 4);
         register(ClientNotification.DEMO_MESSAGE, 5);


### PR DESCRIPTION
Seems like a mistake was made in commit fbd5460d7c595c05a983917e16bf048a85e80ea2 which caused rain to start on `STOP_RAIN` and stop on `START_RAIN` (See GeyserMC/Geyser#144). This PR reverts that and fixes rain.