### PR TITLE
Fix improper values for FLAG_FLYING and FLAG_CAN_FLY

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerAbilitiesPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerAbilitiesPacket.java
@@ -17,8 +17,8 @@ import java.io.IOException;
 @AllArgsConstructor
 public class ServerPlayerAbilitiesPacket implements Packet {
     private static final int FLAG_INVINCIBLE = 0x01;
-    private static final int FLAG_CAN_FLY = 0x02;
-    private static final int FLAG_FLYING = 0x04;
+    private static final int FLAG_FLYING = 0x02;
+    private static final int FLAG_CAN_FLY = 0x04;
     private static final int FLAG_CREATIVE = 0x08;
 
     private boolean invincible;


### PR DESCRIPTION
According to https://wiki.vg/Protocol#Player_Abilities_.28clientbound.29 These values are flipped around, and in my testing it appears so.