### PR TITLE
Add "vanilla Forge" support

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -127,6 +127,9 @@ public class MagicValues {
         register(AttributeType.GENERIC_FLYING_SPEED, "generic.flyingSpeed");
         register(AttributeType.HORSE_JUMP_STRENGTH, "horse.jumpStrength");
         register(AttributeType.ZOMBIE_SPAWN_REINFORCEMENTS, "zombie.spawnReinforcements");
+        register(AttributeType.SWIM_SPEED, "forge.swimSpeed");
+        register(AttributeType.NAMETAG_DISTANCE, "forge.nameTagDistance");
+        register(AttributeType.ENTITY_GRAVITY, "forge.entity_gravity");
 
         register(ModifierType.CREATURE_FLEE_SPEED_BONUS, UUID.fromString("E199AD21-BA8A-4C53-8D13-6182D5C69D3A"));
         register(ModifierType.ENDERMAN_ATTACK_SPEED_BOOST, UUID.fromString("020E0DFB-87AE-4653-9556-831010E291A0"));

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/attribute/AttributeType.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/attribute/AttributeType.java
@@ -17,7 +17,11 @@ public enum AttributeType {
     GENERIC_LUCK(0, -1024, 1024),
     GENERIC_FLYING_SPEED(0.4000000059604645, 0, 1024),
     HORSE_JUMP_STRENGTH(0.7, 0, 2),
-    ZOMBIE_SPAWN_REINFORCEMENTS(0, 0, 1);
+    ZOMBIE_SPAWN_REINFORCEMENTS(0, 0, 1),
+    // Forge - retrieved from Forge source code
+    SWIM_SPEED(1, 0, 1024),
+    NAMETAG_DISTANCE(64, 0, Float.MAX_VALUE),
+    ENTITY_GRAVITY(0.08, -8.0, 8.0);
 
     private final double def;
     private final double min;

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/attribute/AttributeType.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/attribute/AttributeType.java
@@ -18,9 +18,20 @@ public enum AttributeType {
     GENERIC_FLYING_SPEED(0.4000000059604645, 0, 1024),
     HORSE_JUMP_STRENGTH(0.7, 0, 2),
     ZOMBIE_SPAWN_REINFORCEMENTS(0, 0, 1),
-    // Forge - retrieved from Forge source code
+    /**
+     * Required for logging into a Minecraft Forge server
+     * Source: MinecraftForge/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch#10
+     */
     SWIM_SPEED(1, 0, 1024),
+    /**
+     * Required for logging into a Minecraft Forge server
+     * Source: MinecraftForge/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch#11
+     */
     NAMETAG_DISTANCE(64, 0, Float.MAX_VALUE),
+    /**
+     * Required for logging into a Minecraft Forge server
+     * Source: MinecraftForge/patches/minecraft/net/minecraft/entity/LivingEntity.java.patch#12
+     */
     ENTITY_GRAVITY(0.08, -8.0, 8.0);
 
     private final double def;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareCommandsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareCommandsPacket.java
@@ -71,7 +71,9 @@ public class ServerDeclareCommandsPacket implements Packet {
             CommandParser parser = null;
             CommandProperties properties = null;
             if(type == CommandType.ARGUMENT) {
-                parser = MagicValues.key(CommandParser.class, Identifier.formalize(in.readString()));
+                String identifier = Identifier.formalize(in.readString());
+                if (identifier.equals("minecraft:")) continue;
+                parser = MagicValues.key(CommandParser.class, identifier);
                 switch(parser) {
                     case DOUBLE: {
                         byte numberFlags = in.readByte();


### PR DESCRIPTION
This PR fixes two issues when connecting to Forge servers. Both prevent a connection to the server. Neither of these prevent connection to a normal Minecraft server (tested with Paper).

The first issue is detailed in GeyserMC/Geyser#251 - Forge sends an identifier of "minecraft:", with nothing else afterwards. Feel free to be merciless with this code as it's definitely one of those "workarounds" rather than actually implementing.

The second refers to attributes - Forge adds three attributes to a "vanilla Forge" server: swim speed, nametag distance and entity gravity. This PR adds support for these as well. 