### PR TITLE
When a color can't be translated set to NONE instead of null

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/message/ChatColor.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/message/ChatColor.java
@@ -28,7 +28,7 @@ public enum ChatColor {
             }
         }
 
-        return null;
+        return ChatColor.NONE;
     }
 
     @Override


### PR DESCRIPTION
If a JSON TextMessage contains an unrecognized color then the color is set null. This causes NPE issues when trying to parse a Message later.

It also looks like there are a few missing colors which may be the actual cause of this occuring but its probably a good idea to set to NONE for unrecognized colors anyway.

Closes https://github.com/GeyserMC/Geyser/issues/686, Closes https://github.com/GeyserMC/Geyser/issues/557
