### PR TITLE
Add HandPreference for better ClientSettingsPacket handling

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -30,6 +30,7 @@ import com.github.steveice10.mc.protocol.data.game.entity.player.BlockBreakStage
 import com.github.steveice10.mc.protocol.data.game.entity.player.CombatState;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
 import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
+import com.github.steveice10.mc.protocol.data.game.entity.player.HandPreference;
 import com.github.steveice10.mc.protocol.data.game.entity.player.InteractAction;
 import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerAction;
 import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerState;
@@ -1045,6 +1046,9 @@ public class MagicValues {
 
         register(Hand.MAIN_HAND, 0);
         register(Hand.OFF_HAND, 1);
+
+        register(HandPreference.LEFT_HAND, 0);
+        register(HandPreference.RIGHT_HAND, 1);
 
         register(BossBarAction.ADD, 0);
         register(BossBarAction.REMOVE, 1);

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/player/HandPreference.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/player/HandPreference.java
@@ -1,0 +1,6 @@
+package com.github.steveice10.mc.protocol.data.game.entity.player;
+
+public enum HandPreference {
+    LEFT_HAND,
+    RIGHT_HAND;
+}

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientSettingsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientSettingsPacket.java
@@ -1,7 +1,7 @@
 package com.github.steveice10.mc.protocol.packet.ingame.client;
 
 import com.github.steveice10.mc.protocol.data.MagicValues;
-import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
+import com.github.steveice10.mc.protocol.data.game.entity.player.HandPreference;
 import com.github.steveice10.mc.protocol.data.game.setting.ChatVisibility;
 import com.github.steveice10.mc.protocol.data.game.setting.SkinPart;
 import com.github.steveice10.packetlib.io.NetInput;
@@ -28,7 +28,7 @@ public class ClientSettingsPacket implements Packet {
     private @NonNull ChatVisibility chatVisibility;
     private boolean useChatColors;
     private @NonNull List<SkinPart> visibleParts;
-    private @NonNull Hand mainHand;
+    private @NonNull HandPreference mainHand;
 
     @Override
     public void read(NetInput in) throws IOException {
@@ -46,7 +46,7 @@ public class ClientSettingsPacket implements Packet {
             }
         }
 
-        this.mainHand = MagicValues.key(Hand.class, in.readVarInt());
+        this.mainHand = MagicValues.key(HandPreference.class, in.readVarInt());
     }
 
     @Override

--- a/src/test/java/com/github/steveice10/mc/protocol/data/MagicValuesTest.java
+++ b/src/test/java/com/github/steveice10/mc/protocol/data/MagicValuesTest.java
@@ -30,6 +30,7 @@ import com.github.steveice10.mc.protocol.data.game.entity.player.BlockBreakStage
 import com.github.steveice10.mc.protocol.data.game.entity.player.CombatState;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
 import com.github.steveice10.mc.protocol.data.game.entity.player.Hand;
+import com.github.steveice10.mc.protocol.data.game.entity.player.HandPreference;
 import com.github.steveice10.mc.protocol.data.game.entity.player.InteractAction;
 import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerAction;
 import com.github.steveice10.mc.protocol.data.game.entity.player.PlayerState;
@@ -194,6 +195,7 @@ public class MagicValuesTest {
         this.register(AdvancementTabAction.class, Integer.class);
         this.register(ResourcePackStatus.class, Integer.class);
         this.register(Hand.class, Integer.class);
+        this.register(HandPreference.class, Integer.class);
         this.register(BossBarAction.class, Integer.class);
         this.register(BossBarColor.class, Integer.class);
         this.register(BossBarDivision.class, Integer.class);


### PR DESCRIPTION
This make the ClientSettingsPacket make more sense as before left hand was `Hand.MAIN_HAND` and right hand was `Hand.OFF_HAND` whereas now it is HandPreference.LEFT_HAND` and `HandPreference.RIGHT_HAND` respectively.

Also noticed BeaconValueType was unused but I left removing that out of this PR as it is out of scope.