### PR TITLE
 Fix "set" in FlexibleStorage

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/FlexibleStorage.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/FlexibleStorage.java
@@ -84,7 +84,7 @@ public class FlexibleStorage {
 
         int cellIndex = (int) (index * divideMultiply + divideAdd >> 32L >> divideShift);
         int bitIndex = (index - cellIndex * valuesPerLong) * bitsPerEntry;
-        data[cellIndex] &= ~(maxEntryValue << bitIndex) | (value & maxEntryValue) << bitIndex;
+        data[cellIndex] = ~(maxEntryValue << bitIndex) | (value & maxEntryValue) << bitIndex;
     }
 
     public FlexibleStorage transferData(int newBitsPerEntry, IntFunction<Integer> valueGetter) {

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/FlexibleStorage.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/FlexibleStorage.java
@@ -84,7 +84,7 @@ public class FlexibleStorage {
 
         int cellIndex = (int) (index * divideMultiply + divideAdd >> 32L >> divideShift);
         int bitIndex = (index - cellIndex * valuesPerLong) * bitsPerEntry;
-        this.data[startIndex] = this.data[startIndex] & ~(this.maxEntryValue << startBitSubIndex) | ((long) value & this.maxEntryValue) << startBitSubIndex;
+        this.data[cellIndex] = this.data[cellIndex] & ~(this.maxEntryValue << bitIndex) | ((long) value & this.maxEntryValue) << bitIndex;
     }
 
     public FlexibleStorage transferData(int newBitsPerEntry, IntFunction<Integer> valueGetter) {

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/FlexibleStorage.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/FlexibleStorage.java
@@ -84,7 +84,7 @@ public class FlexibleStorage {
 
         int cellIndex = (int) (index * divideMultiply + divideAdd >> 32L >> divideShift);
         int bitIndex = (index - cellIndex * valuesPerLong) * bitsPerEntry;
-        data[cellIndex] = ~(maxEntryValue << bitIndex) | (value & maxEntryValue) << bitIndex;
+        this.data[startIndex] = this.data[startIndex] & ~(this.maxEntryValue << startBitSubIndex) | ((long) value & this.maxEntryValue) << startBitSubIndex;
     }
 
     public FlexibleStorage transferData(int newBitsPerEntry, IntFunction<Integer> valueGetter) {


### PR DESCRIPTION
The assignment using `&=` seems to make it so that once a value is set to 0 it can never be set to anything else, because when you do a bitwise AND with 0 it stays as 0. This means that you can't write data to chunks, which use FlexibleStorage. Setting this to `=` fixes that. Is there any reason why this was `&=` or was it a mistake?
Edit: That didn't work, @Johni0702 explained below, but it should be right now