### PR TITLE
Palette optimization

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/Chunk.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/Chunk.java
@@ -99,14 +99,14 @@ public class Chunk {
 
     private void resizePalette() {
         Palette oldPalette = this.palette;
-        int[] oldData = this.storage.toIntArray();
+        BitStorage oldData = this.storage;
 
-        int bitsPerEntry = sanitizeBitsPerEntry(this.storage.getBitsPerEntry() + 1);
+        int bitsPerEntry = sanitizeBitsPerEntry(oldData.getBitsPerEntry() + 1);
         this.palette = createPalette(bitsPerEntry);
         this.storage = new BitStorage(bitsPerEntry, CHUNK_SIZE);
 
-        for(int i = 0; i < oldData.length; i++) {
-            this.storage.set(i, this.palette.stateToId(oldPalette.idToState(oldData[i])));
+        for(int i = 0; i < CHUNK_SIZE; i++) {
+            this.storage.set(i, this.palette.stateToId(oldPalette.idToState(oldData.get(i))));
         }
     }
 

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
@@ -2,9 +2,6 @@ package com.github.steveice10.mc.protocol.data.game.chunk.palette;
 
 import lombok.EqualsAndHashCode;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
  * A palette backed by a List.
  */

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
@@ -12,25 +12,32 @@ import java.util.List;
 public class ListPalette implements Palette {
     private final int maxId;
 
-    private final List<Integer> data = new ArrayList<>();
+    private final int[] data;
+    private int nextId = 1;
 
     public ListPalette(int bitsPerEntry) {
         this.maxId = (1 << bitsPerEntry) - 1;
 
-        this.data.add(0);
+        this.data = new int[this.maxId + 1];
     }
 
     @Override
     public int size() {
-        return this.data.size();
+        return this.nextId;
     }
 
     @Override
     public int stateToId(int state) {
-        int id = this.data.indexOf(state);
+        int id = -1;
+        for(int i = 0; i < this.nextId; i++) { // Linear search for state
+            if(this.data[i] == state) {
+                id = i;
+                break;
+            }
+        }
         if(id == -1 && this.size() < this.maxId + 1) {
-            this.data.add(id);
-            id = this.data.size() - 1;
+            id = this.nextId++;
+            this.data[id] = state;
         }
 
         return id;
@@ -38,8 +45,8 @@ public class ListPalette implements Palette {
 
     @Override
     public int idToState(int id) {
-        if(id >= 0 && id < this.data.size()) {
-            return this.data.get(id);
+        if(id >= 0 && id < this.size()) {
+            return this.data[id];
         } else {
             return 0;
         }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
@@ -1,9 +1,8 @@
 package com.github.steveice10.mc.protocol.data.game.chunk.palette;
 
+import io.netty.util.collection.IntObjectHashMap;
+import io.netty.util.collection.IntObjectMap;
 import lombok.EqualsAndHashCode;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A palette backed by a map.
@@ -13,14 +12,14 @@ public class MapPalette implements Palette {
     private final int maxId;
 
     private final int[] idToState;
-    private final Map<Integer, Integer> stateToId = new HashMap<>();
+    private final IntObjectMap<Integer> stateToId = new IntObjectHashMap<>();
     private int nextId = 1;
 
     public MapPalette(int bitsPerEntry) {
         this.maxId = (1 << bitsPerEntry) - 1;
 
         this.idToState = new int[this.maxId + 1];
-        this.stateToId.put(0, 0);
+        this.stateToId.put(0, (Integer) 0);
     }
 
     @Override

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
@@ -12,20 +12,20 @@ import java.util.Map;
 public class MapPalette implements Palette {
     private final int maxId;
 
-    private final Map<Integer, Integer> idToState = new HashMap<>();
+    private final int[] idToState;
     private final Map<Integer, Integer> stateToId = new HashMap<>();
     private int nextId = 1;
 
     public MapPalette(int bitsPerEntry) {
         this.maxId = (1 << bitsPerEntry) - 1;
 
-        this.idToState.put(0, 0);
+        this.idToState = new int[this.maxId + 1];
         this.stateToId.put(0, 0);
     }
 
     @Override
     public int size() {
-        return this.idToState.size();
+        return this.nextId;
     }
 
     @Override
@@ -33,7 +33,7 @@ public class MapPalette implements Palette {
         Integer id = this.stateToId.get(state);
         if(id == null && this.size() < this.maxId + 1) {
             id = this.nextId++;
-            this.idToState.put(id, state);
+            this.idToState[id] = state;
             this.stateToId.put(state, id);
         }
 
@@ -46,9 +46,8 @@ public class MapPalette implements Palette {
 
     @Override
     public int idToState(int id) {
-        Integer state = this.idToState.get(id);
-        if(state != null) {
-            return state;
+        if(id >= 0 && id < this.size()) {
+            return this.idToState[id];
         } else {
             return 0;
         }


### PR DESCRIPTION
This eliminates a lot of unnecessary boxing when reading chunk data by making `ListPalette` and `MapPalette` use an `int[]` instead of a `List<Integer>` and `Map<Integer, Integer>`, respectively.

`MapPalette#stateToIds` now uses an `IntObjectMap<Integer>` instead of `Map<Integer, Integer>`. This is significantly better because it eliminates boxing allocations for keys (which will account for the majority of boxing overhead), and the values only have to be boxed once.

`Chunk#resizePalette` no longer copies all the old data into an `int[]` before transferring the data into the resized `BitStorage`. There seems to be no reason for this, as far as I can tell it's just needless allocation of a rather large array.