### PR TITLE
palette does not always start with zero...

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
@@ -10,7 +10,7 @@ public class ListPalette implements Palette {
     private final int maxId;
 
     private final int[] data;
-    private int nextId = 1;
+    private int nextId = 0;
 
     public ListPalette(int bitsPerEntry) {
         this.maxId = (1 << bitsPerEntry) - 1;

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
@@ -13,13 +13,12 @@ public class MapPalette implements Palette {
 
     private final int[] idToState;
     private final IntObjectMap<Integer> stateToId = new IntObjectHashMap<>();
-    private int nextId = 1;
+    private int nextId = 0;
 
     public MapPalette(int bitsPerEntry) {
         this.maxId = (1 << bitsPerEntry) - 1;
 
         this.idToState = new int[this.maxId + 1];
-        this.stateToId.put(0, (Integer) 0);
     }
 
     @Override


### PR DESCRIPTION
I retained this behavior when optimizing palettes in my last PR, but some additional testing has shown that the palette does not, in fact, always start with zero. A perfect example can be found by joining Hypixel, the chunk section at `0, 4, 0` has air at palette index 3.

Example of effects with Geyser:
Before:
![image](https://i.daporkchop.net/u3VMcAfq.png)
After:
![image](https://i.daporkchop.net/6ufkQB8y.png)