### PR TITLE
allow duplicate entries in palette

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/Chunk.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/Chunk.java
@@ -33,13 +33,7 @@ public class Chunk {
         int blockCount = in.readShort();
         int bitsPerEntry = in.readUnsignedByte();
 
-        Palette palette = createPalette(bitsPerEntry);
-        if(!(palette instanceof GlobalPalette)) {
-            int paletteLength = in.readVarInt();
-            for(int i = 0; i < paletteLength; i++) {
-                palette.stateToId(in.readVarInt());
-            }
-        }
+        Palette palette = readPalette(bitsPerEntry, in);
 
         BitStorage storage = new BitStorage(bitsPerEntry, CHUNK_SIZE, in.readLongs(in.readVarInt()));
         return new Chunk(blockCount, palette, storage);
@@ -115,6 +109,16 @@ public class Chunk {
             return new ListPalette(bitsPerEntry);
         } else if(bitsPerEntry <= MAX_PALETTE_BITS_PER_ENTRY) {
             return new MapPalette(bitsPerEntry);
+        } else {
+            return new GlobalPalette();
+        }
+    }
+
+    private static Palette readPalette(int bitsPerEntry, NetInput in) throws IOException {
+        if(bitsPerEntry <= MIN_PALETTE_BITS_PER_ENTRY) {
+            return new ListPalette(bitsPerEntry, in);
+        } else if(bitsPerEntry <= MAX_PALETTE_BITS_PER_ENTRY) {
+            return new MapPalette(bitsPerEntry, in);
         } else {
             return new GlobalPalette();
         }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
@@ -1,6 +1,9 @@
 package com.github.steveice10.mc.protocol.data.game.chunk.palette;
 
+import com.github.steveice10.packetlib.io.NetInput;
 import lombok.EqualsAndHashCode;
+
+import java.io.IOException;
 
 /**
  * A palette backed by a List.
@@ -16,6 +19,16 @@ public class ListPalette implements Palette {
         this.maxId = (1 << bitsPerEntry) - 1;
 
         this.data = new int[this.maxId + 1];
+    }
+
+    public ListPalette(int bitsPerEntry, NetInput in) throws IOException {
+        this(bitsPerEntry);
+
+        int paletteLength = in.readVarInt();
+        for(int i = 0; i < paletteLength; i++) {
+            this.data[i] = in.readVarInt();
+        }
+        this.nextId = paletteLength;
     }
 
     @Override

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
@@ -1,8 +1,11 @@
 package com.github.steveice10.mc.protocol.data.game.chunk.palette;
 
+import com.github.steveice10.packetlib.io.NetInput;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
 import lombok.EqualsAndHashCode;
+
+import java.io.IOException;
 
 /**
  * A palette backed by a map.
@@ -19,6 +22,18 @@ public class MapPalette implements Palette {
         this.maxId = (1 << bitsPerEntry) - 1;
 
         this.idToState = new int[this.maxId + 1];
+    }
+
+    public MapPalette(int bitsPerEntry, NetInput in) throws IOException {
+        this(bitsPerEntry);
+
+        int paletteLength = in.readVarInt();
+        for(int i = 0; i < paletteLength; i++) {
+            int state = in.readVarInt();
+            this.idToState[i] = state;
+            this.stateToId.putIfAbsent(state, i);
+        }
+        this.nextId = paletteLength;
     }
 
     @Override


### PR DESCRIPTION
Woohoo, yet another chunk palette decoding fix! *screams internally*

This PR allows decoding chunks with duplicate block state IDs in their palette. I'm not sure which circumstances are required for a chunk's palette to actually *have* duplicate entries for the same state, but it's occurred in at least two distinct test worlds and the vanilla client accepts it perfectly fine.