### PR TITLE
Add full support for the UNKNOWN gamemode

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -262,6 +262,7 @@ public class MagicValues {
         register(CombatState.END_COMBAT, 1);
         register(CombatState.ENTITY_DEAD, 2);
 
+        register(GameMode.UNKNOWN, -1);
         register(GameMode.SURVIVAL, 0);
         register(GameMode.CREATIVE, 1);
         register(GameMode.ADVENTURE, 2);

--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -262,7 +262,7 @@ public class MagicValues {
         register(CombatState.END_COMBAT, 1);
         register(CombatState.ENTITY_DEAD, 2);
 
-        register(GameMode.UNKNOWN, -1);
+        register(GameMode.UNKNOWN, 255); // https://bugs.mojang.com/browse/MC-189885 - should be -1
         register(GameMode.SURVIVAL, 0);
         register(GameMode.CREATIVE, 1);
         register(GameMode.ADVENTURE, 2);

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/player/GameMode.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/player/GameMode.java
@@ -1,10 +1,6 @@
 package com.github.steveice10.mc.protocol.data.game.entity.player;
 
-import com.github.steveice10.mc.protocol.data.MagicValues;
 import com.github.steveice10.mc.protocol.data.game.world.notify.ClientNotificationValue;
-import com.github.steveice10.packetlib.io.NetOutput;
-
-import java.io.IOException;
 
 public enum GameMode implements ClientNotificationValue {
     SURVIVAL,

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/player/GameMode.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/player/GameMode.java
@@ -10,19 +10,7 @@ public enum GameMode implements ClientNotificationValue {
     SURVIVAL,
     CREATIVE,
     ADVENTURE,
-    SPECTATOR;
+    SPECTATOR,
+    UNKNOWN
 
-    public static GameMode readPreviousGameMode(int gamemode) {
-        if (gamemode == 255) // https://bugs.mojang.com/browse/MC-189885
-            return null; // Undefined gamemode; we're treating it as null
-        return MagicValues.key(GameMode.class, gamemode);
-    }
-
-    public static void writePreviousGameMode(NetOutput out, GameMode gamemode) throws IOException {
-        if (gamemode == null) {
-            out.writeByte(255);
-        } else {
-            out.writeByte(MagicValues.value(Integer.class, gamemode));
-        }
-    }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
@@ -47,7 +47,7 @@ public class ServerJoinGamePacket implements Packet {
         this.hardcore = in.readBoolean();
         int gameMode = in.readUnsignedByte();
         this.gameMode = MagicValues.key(GameMode.class, gameMode & GAMEMODE_MASK);
-        this.previousGamemode = GameMode.readPreviousGameMode(in.readUnsignedByte());
+        this.previousGamemode = MagicValues.key(GameMode.class, in.readUnsignedByte());
         this.worldCount = in.readVarInt();
         this.worldNames = new String[this.worldCount];
         for (int i = 0; i < this.worldCount; i++) {
@@ -73,7 +73,7 @@ public class ServerJoinGamePacket implements Packet {
         int gameMode = MagicValues.value(Integer.class, this.gameMode) & GAMEMODE_MASK;
 
         out.writeByte(gameMode);
-        GameMode.writePreviousGameMode(out, this.previousGamemode);
+        out.writeByte(MagicValues.value(Integer.class, this.previousGamemode));
         out.writeVarInt(this.worldCount);
         for (String worldName : this.worldNames) {
             out.writeString(worldName);

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
@@ -36,7 +36,7 @@ public class ServerRespawnPacket implements Packet {
         this.worldName = in.readString();
         this.hashedSeed = in.readLong();
         this.gamemode = MagicValues.key(GameMode.class, in.readUnsignedByte());
-        this.previousGamemode = GameMode.readPreviousGameMode(in.readUnsignedByte());
+        this.previousGamemode = MagicValues.key(GameMode.class, in.readUnsignedByte());
         this.debug = in.readBoolean();
         this.flat = in.readBoolean();
         this.copyMetadata = in.readBoolean();
@@ -48,7 +48,7 @@ public class ServerRespawnPacket implements Packet {
         out.writeString(this.worldName);
         out.writeLong(this.hashedSeed);
         out.writeByte(MagicValues.value(Integer.class, this.gamemode));
-        GameMode.writePreviousGameMode(out, this.previousGamemode);
+        out.writeByte(MagicValues.value(Integer.class, this.previousGamemode));
         out.writeBoolean(this.debug);
         out.writeBoolean(this.flat);
         out.writeBoolean(this.copyMetadata);

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerNotifyClientPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerNotifyClientPacket.java
@@ -34,7 +34,7 @@ public class ServerNotifyClientPacket implements Packet {
         this.notification = MagicValues.key(ClientNotification.class, in.readUnsignedByte());
         float value = in.readFloat();
         if(this.notification == ClientNotification.CHANGE_GAMEMODE) {
-            this.value = MagicValues.key(GameMode.class, (int) value);
+            this.value = MagicValues.key(GameMode.class, ((int) value == -1) ? 255 : (int) value); // https://bugs.mojang.com/browse/MC-189885 - since we read as a float this bug doesn't apply here
         } else if(this.notification == ClientNotification.DEMO_MESSAGE) {
             this.value = MagicValues.key(DemoMessageValue.class, (int) value);
         } else if(this.notification == ClientNotification.ENTER_CREDITS) {
@@ -52,7 +52,9 @@ public class ServerNotifyClientPacket implements Packet {
     public void write(NetOutput out) throws IOException {
         out.writeByte(MagicValues.value(Integer.class, this.notification));
         float value = 0;
-        if(this.value instanceof Enum<?>) {
+        if (this.value instanceof GameMode && this.value == GameMode.UNKNOWN) {
+            value = -1;
+        } else if(this.value instanceof Enum<?>) {
             value = MagicValues.value(Integer.class, (Enum<?>) this.value);
         } else if(this.value instanceof RainStrengthValue) {
             value = ((RainStrengthValue) this.value).getStrength();


### PR DESCRIPTION
Previously we correctly handled the unknown gamemode for 'previous gamemode'; however, this functionality can extend to the main gamemode. The gamemode writing we've been doing has been replaced with the UNKNOWN enum, so we aren't dealing with a null value for parameters that are marked NonNull.