### PR TITLE
Allow recipe data to be null

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/recipe/data/ShapedRecipeData.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/recipe/data/ShapedRecipeData.java
@@ -13,5 +13,5 @@ public class ShapedRecipeData implements RecipeData {
     private final int height;
     private final @NonNull String group;
     private final @NonNull Ingredient[] ingredients;
-    private final @NonNull ItemStack result;
+    private final ItemStack result;
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/recipe/data/ShapelessRecipeData.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/recipe/data/ShapelessRecipeData.java
@@ -11,5 +11,5 @@ import lombok.NonNull;
 public class ShapelessRecipeData implements RecipeData {
     private final @NonNull String group;
     private final @NonNull Ingredient[] ingredients;
-    private final @NonNull ItemStack result;
+    private final ItemStack result;
 }


### PR DESCRIPTION
Using datapacks, this can end up being null. Example: https://www.planetminecraft.com/data-pack/true-survival-a-hardcore-minecraft-experience/ (used to set recipes as doing nothing)