### PR TITLE
Add a raw message attribute to ServerChatPacket

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerChatPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerChatPacket.java
@@ -4,7 +4,6 @@ import com.github.steveice10.mc.protocol.data.MagicValues;
 import com.github.steveice10.mc.protocol.data.game.MessageType;
 import com.github.steveice10.mc.protocol.data.message.Message;
 import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
-import com.github.steveice10.mc.protocol.data.message.MessageSerializer;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
@@ -13,6 +12,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
 import java.io.IOException;
@@ -21,11 +21,14 @@ import java.util.UUID;
 @Data
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 @AllArgsConstructor
 public class ServerChatPacket implements Packet {
     private @NonNull Message message;
     private @NonNull MessageType type;
     private @NonNull UUID senderUuid;
+
+    private String rawMessage;
 
     public ServerChatPacket(@NonNull String text) {
         this(MessageSerializer.fromString(text));
@@ -49,7 +52,8 @@ public class ServerChatPacket implements Packet {
 
     @Override
     public void read(NetInput in) throws IOException {
-        this.message = MessageSerializer.fromString(in.readString());
+        this.rawMessage = in.readString();
+        this.message = MessageSerializer.fromString(this.rawMessage);
         this.type = MagicValues.key(MessageType.class, in.readByte());
         this.senderUuid = in.readUUID();
     }


### PR DESCRIPTION
This allows projects such as Geyser to get the raw json string from the message instead of converting the parsed message back. This means we don't have to worry about slight conversion inconsistency, a better solution would be to replace the current message class and handling with a library such as [Adventure](https://github.com/KyoriPowered/adventure) but that's out of scope for this PR.