### PR TITLE
Fix magic values of PistonValue

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -892,9 +892,9 @@ public class MagicValues {
 
         register(PistonValue.DOWN, 0);
         register(PistonValue.UP, 1);
-        register(PistonValue.SOUTH, 2);
-        register(PistonValue.WEST, 3);
-        register(PistonValue.NORTH, 4);
+        register(PistonValue.NORTH, 2);
+        register(PistonValue.SOUTH, 3);
+        register(PistonValue.WEST, 4);
         register(PistonValue.EAST, 5);
 
         register(SoundEffect.BLOCK_DISPENSER_DISPENSE, 1000);

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/world/block/value/PistonValue.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/world/block/value/PistonValue.java
@@ -3,8 +3,8 @@ package com.github.steveice10.mc.protocol.data.game.world.block.value;
 public enum PistonValue implements BlockValue {
     DOWN,
     UP,
+    NORTH,
     SOUTH,
     WEST,
-    NORTH,
-    EAST;
+    EAST
 }


### PR DESCRIPTION
These values were inconsistent while testing pistons on 1.16.4.

![image](https://user-images.githubusercontent.com/4722249/101686284-d9b38d00-3a36-11eb-8be1-73666bdf7a80.png)