### PR TITLE
Add @With annotation to packet classes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.12</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/handshake/client/HandshakePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/handshake/client/HandshakePacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientChatPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientChatPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientKeepAlivePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientKeepAlivePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientLockDifficultyPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientLockDifficultyPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientPluginMessagePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientPluginMessagePacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientRequestPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientRequestPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientResourcePackStatusPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientResourcePackStatusPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientSetDifficultyPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientSetDifficultyPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientSettingsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientSettingsPacket.java
@@ -13,12 +13,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientTabCompletePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/ClientTabCompletePacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerAbilitiesPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerAbilitiesPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerActionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerActionPacket.java
@@ -13,10 +13,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerChangeHeldItemPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerChangeHeldItemPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerInteractEntityPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerInteractEntityPacket.java
@@ -12,10 +12,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerMovementPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerMovementPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerPlaceBlockPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerPlaceBlockPacket.java
@@ -13,10 +13,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerPositionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerPositionPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerPositionRotationPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerPositionRotationPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerRotationPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerRotationPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerStatePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerStatePacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerSwingArmPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerSwingArmPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerUseItemPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/player/ClientPlayerUseItemPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientClickWindowButtonPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientClickWindowButtonPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientCloseWindowPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientCloseWindowPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientConfirmTransactionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientConfirmTransactionPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientCraftingBookStatePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientCraftingBookStatePacket.java
@@ -6,18 +6,22 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @ToString
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ClientCraftingBookStatePacket implements Packet {
     private @NonNull CraftingBookStateType type;
     private boolean bookOpen;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientCreativeInventoryActionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientCreativeInventoryActionPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientDisplayedRecipePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientDisplayedRecipePacket.java
@@ -4,18 +4,22 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.ToString;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @ToString
 @EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ClientDisplayedRecipePacket implements Packet {
     private @NonNull String recipeId;
 

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientEditBookPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientEditBookPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientMoveItemToHotbarPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientMoveItemToHotbarPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientPrepareCraftingGridPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientPrepareCraftingGridPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientRenameItemPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientRenameItemPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientSelectTradePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientSelectTradePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientSetBeaconEffectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientSetBeaconEffectPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientUpdateCommandBlockMinecartPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientUpdateCommandBlockMinecartPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientUpdateCommandBlockPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientUpdateCommandBlockPacket.java
@@ -12,10 +12,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientUpdateJigsawBlockPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientUpdateJigsawBlockPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientUpdateStructureBlockPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientUpdateStructureBlockPacket.java
@@ -15,10 +15,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientWindowActionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/window/ClientWindowActionPacket.java
@@ -18,10 +18,12 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ClientWindowActionPacket implements Packet {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientBlockNBTRequestPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientBlockNBTRequestPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientEntityNBTRequestPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientEntityNBTRequestPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientGenerateStructuresPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientGenerateStructuresPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientSpectatePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientSpectatePacket.java
@@ -9,11 +9,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.UUID;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientSteerBoatPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientSteerBoatPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientSteerVehiclePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientSteerVehiclePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientTeleportConfirmPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientTeleportConfirmPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientUpdateSignPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientUpdateSignPacket.java
@@ -9,11 +9,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ClientUpdateSignPacket implements Packet {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientVehicleMovePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/client/world/ClientVehicleMovePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerAdvancementTabPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerAdvancementTabPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerAdvancementsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerAdvancementsPacket.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerBossBarPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerBossBarPacket.java
@@ -9,18 +9,22 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 import java.util.UUID;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerBossBarPacket implements Packet {
     private @NonNull UUID uuid;
     private @NonNull BossBarAction action;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerChatPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerChatPacket.java
@@ -12,12 +12,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 import java.util.UUID;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerCombatPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerCombatPacket.java
@@ -7,15 +7,19 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerCombatPacket implements Packet {
     private CombatState combatState;
 

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareCommandsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareCommandsPacket.java
@@ -23,10 +23,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareRecipesPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareRecipesPacket.java
@@ -21,10 +21,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareTagsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDeclareTagsPacket.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -16,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDifficultyPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDifficultyPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDisconnectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerDisconnectPacket.java
@@ -10,11 +10,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerEntitySoundEffectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerEntitySoundEffectPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
@@ -13,10 +13,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerKeepAlivePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerKeepAlivePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerPlayerListDataPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerPlayerListDataPacket.java
@@ -10,11 +10,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerPlayerListEntryPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerPlayerListEntryPacket.java
@@ -15,6 +15,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
@@ -23,6 +24,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerPluginMessagePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerPluginMessagePacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerResourcePackSendPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerResourcePackSendPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
@@ -13,10 +13,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerSetCompressionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerSetCompressionPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerSetCooldownPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerSetCooldownPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerStatisticsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerStatisticsPacket.java
@@ -23,12 +23,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerStopSoundPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerStopSoundPacket.java
@@ -15,10 +15,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerSwitchCameraPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerSwitchCameraPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerTabCompletePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerTabCompletePacket.java
@@ -9,12 +9,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerTabCompletePacket implements Packet {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerTitlePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerTitlePacket.java
@@ -7,17 +7,21 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerTitlePacket implements Packet {
     private @NonNull TitleAction action;
 

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerUnlockRecipesPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerUnlockRecipesPacket.java
@@ -6,17 +6,21 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerUnlockRecipesPacket implements Packet {
     private @NonNull UnlockRecipesAction action;
 

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityAnimationPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityAnimationPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityAttachPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityAttachPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityCollectItemPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityCollectItemPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityDestroyPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityDestroyPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityEffectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityEffectPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityEquipmentPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityEquipmentPacket.java
@@ -13,12 +13,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityHeadLookPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityHeadLookPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityMetadataPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityMetadataPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityMovementPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityMovementPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityPositionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityPositionPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityPositionRotationPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityPositionRotationPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityPropertiesPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityPropertiesPacket.java
@@ -15,12 +15,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityRemoveEffectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityRemoveEffectPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityRotationPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityRotationPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntitySetPassengersPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntitySetPassengersPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityStatusPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityStatusPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityTeleportPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityTeleportPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityVelocityPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerEntityVelocityPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerVehicleMovePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/ServerVehicleMovePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerAbilitiesPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerAbilitiesPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerActionAckPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerActionAckPacket.java
@@ -12,10 +12,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerChangeHeldItemPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerChangeHeldItemPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerFacingPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerFacingPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerHealthPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerHealthPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerPositionRotationPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerPositionRotationPacket.java
@@ -6,9 +6,11 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -16,8 +18,10 @@ import java.util.Arrays;
 import java.util.List;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerPlayerPositionRotationPacket implements Packet {
     private double x;
     private double y;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerSetExperiencePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/player/ServerPlayerSetExperiencePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnEntityPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnEntityPacket.java
@@ -18,11 +18,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.UUID;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnExpOrbPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnExpOrbPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnLivingEntityPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnLivingEntityPacket.java
@@ -11,11 +11,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.UUID;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPaintingPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPaintingPacket.java
@@ -13,11 +13,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.UUID;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPlayerPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/entity/spawn/ServerSpawnPlayerPacket.java
@@ -9,11 +9,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.UUID;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/scoreboard/ServerDisplayScoreboardPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/scoreboard/ServerDisplayScoreboardPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/scoreboard/ServerScoreboardObjectivePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/scoreboard/ServerScoreboardObjectivePacket.java
@@ -12,11 +12,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerScoreboardObjectivePacket implements Packet {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/scoreboard/ServerTeamPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/scoreboard/ServerTeamPacket.java
@@ -11,18 +11,22 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerTeamPacket implements Packet {
     private @NonNull String teamName;
     private @NonNull TeamAction action;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/scoreboard/ServerUpdateScorePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/scoreboard/ServerUpdateScorePacket.java
@@ -6,15 +6,19 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerUpdateScorePacket implements Packet {
     private String entry;
     private ScoreboardAction action;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerCloseWindowPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerCloseWindowPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerConfirmTransactionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerConfirmTransactionPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerOpenBookPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerOpenBookPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerOpenHorseWindowPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerOpenHorseWindowPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerOpenWindowPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerOpenWindowPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerPreparedCraftingGridPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerPreparedCraftingGridPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerSetSlotPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerSetSlotPacket.java
@@ -9,10 +9,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerTradeListPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerTradeListPacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerWindowItemsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerWindowItemsPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerWindowPropertyPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/window/ServerWindowPropertyPacket.java
@@ -10,10 +10,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerBlockBreakAnimPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerBlockBreakAnimPacket.java
@@ -12,10 +12,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerBlockChangePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerBlockChangePacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerBlockValuePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerBlockValuePacket.java
@@ -25,10 +25,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerChunkDataPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerChunkDataPacket.java
@@ -15,12 +15,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerExplosionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerExplosionPacket.java
@@ -10,12 +10,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerMapDataPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerMapDataPacket.java
@@ -14,11 +14,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerMultiBlockChangePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerMultiBlockChangePacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerMultiBlockChangePacket implements Packet {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerNBTResponsePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerNBTResponsePacket.java
@@ -11,10 +11,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerNotifyClientPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerNotifyClientPacket.java
@@ -18,10 +18,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerOpenTileEntityEditorPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerOpenTileEntityEditorPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerPlayBuiltinSoundPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerPlayBuiltinSoundPacket.java
@@ -12,10 +12,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerPlayEffectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerPlayEffectPacket.java
@@ -22,10 +22,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerPlaySoundPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerPlaySoundPacket.java
@@ -15,10 +15,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerSpawnParticlePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerSpawnParticlePacket.java
@@ -13,10 +13,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerSpawnPositionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerSpawnPositionPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUnloadChunkPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUnloadChunkPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateLightPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateLightPacket.java
@@ -9,11 +9,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.util.Arrays;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerUpdateLightPacket implements Packet {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateTileEntityPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateTileEntityPacket.java
@@ -14,10 +14,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateTimePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateTimePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateViewDistancePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateViewDistancePacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateViewPositionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateViewPositionPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerWorldBorderPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerWorldBorderPacket.java
@@ -6,16 +6,20 @@ import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ServerWorldBorderPacket implements Packet {
     private @NonNull WorldBorderAction action;
 

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/client/LoginPluginResponsePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/client/LoginPluginResponsePacket.java
@@ -7,10 +7,12 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class LoginPluginResponsePacket implements Packet {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/client/LoginStartPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/client/LoginStartPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/EncryptionRequestPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/EncryptionRequestPacket.java
@@ -9,6 +9,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -17,6 +18,7 @@ import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/LoginDisconnectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/LoginDisconnectPacket.java
@@ -10,11 +10,13 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/LoginPluginRequestPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/LoginPluginRequestPacket.java
@@ -9,10 +9,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/LoginSetCompressionPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/LoginSetCompressionPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/LoginSuccessPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/server/LoginSuccessPacket.java
@@ -10,10 +10,12 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/status/client/StatusPingPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/status/client/StatusPingPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/status/client/StatusQueryPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/status/client/StatusQueryPacket.java
@@ -7,10 +7,12 @@ import lombok.AccessLevel;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor
 public class StatusQueryPacket implements Packet {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/status/server/StatusPongPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/status/server/StatusPongPacket.java
@@ -8,10 +8,12 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import lombok.With;
 
 import java.io.IOException;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/status/server/StatusResponsePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/status/server/StatusResponsePacket.java
@@ -19,12 +19,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import lombok.With;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 @Data
+@With
 @Setter(AccessLevel.NONE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor


### PR DESCRIPTION
This PR adds the `@With` annotation to all packet classes, generating copy functions such as
```java
packet = packet.withMessage(newComponent)
```

Since we're using MCProtocolLib for our internal packet manipulation library, such copy functions are very useful to alter packets without having to explicitly copy all other fields over.