### PR TITLE
Draft: Switch from OpenNBT to adventure-nbt

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jdk.version>1.8</jdk.version>
-        <argLine></argLine>
+        <adventure.version>4.7.0</adventure.version>
     </properties>
 
     <licenses>
@@ -55,12 +55,6 @@
     <dependencies>
         <dependency>
             <groupId>com.github.steveice10</groupId>
-            <artifactId>opennbt</artifactId>
-            <version>1.3</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.github.steveice10</groupId>
             <artifactId>packetlib</artifactId>
             <version>1.8</version>
             <scope>compile</scope>
@@ -74,7 +68,12 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.2.0</version>
+            <version>${adventure.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-nbt</artifactId>
+            <version>${adventure.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/NBT.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/NBT.java
@@ -1,9 +1,9 @@
 package com.github.steveice10.mc.protocol.data.game;
 
-import com.github.steveice10.opennbt.NBTIO;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
+import net.kyori.adventure.nbt.BinaryTagIO;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,8 +13,8 @@ public class NBT {
     private NBT() {
     }
 
-    public static CompoundTag read(NetInput in) throws IOException {
-        return (CompoundTag) NBTIO.readTag(new InputStream() {
+    public static CompoundBinaryTag read(NetInput in) throws IOException {
+        return BinaryTagIO.reader().read(new InputStream() {
             @Override
             public int read() throws IOException {
                 return in.readUnsignedByte();
@@ -22,12 +22,12 @@ public class NBT {
         });
     }
 
-    public static void write(NetOutput out, CompoundTag tag) throws IOException {
-        NBTIO.writeTag(new OutputStream() {
+    public static void write(NetOutput out, CompoundBinaryTag nbt) throws IOException {
+        BinaryTagIO.writer().write(nbt, new OutputStream() {
             @Override
             public void write(int b) throws IOException {
                 out.writeByte(b);
             }
-        }, tag);
+        });
     }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/Column.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/Column.java
@@ -1,8 +1,8 @@
 package com.github.steveice10.mc.protocol.data.game.chunk;
 
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import lombok.Data;
 import lombok.NonNull;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.util.Arrays;
 
@@ -11,15 +11,15 @@ public class Column {
     private final int x;
     private final int z;
     private final @NonNull Chunk[] chunks;
-    private final @NonNull CompoundTag[] tileEntities;
-    private final @NonNull CompoundTag heightMaps;
+    private final @NonNull CompoundBinaryTag[] tileEntities;
+    private final @NonNull CompoundBinaryTag heightMaps;
     private final int[] biomeData;
 
-    public Column(int x, int z, @NonNull Chunk[] chunks, @NonNull CompoundTag[] tileEntities, @NonNull CompoundTag heightMaps) {
+    public Column(int x, int z, @NonNull Chunk[] chunks, @NonNull CompoundBinaryTag[] tileEntities, @NonNull CompoundBinaryTag heightMaps) {
         this(x, z, chunks, tileEntities, heightMaps, null);
     }
 
-    public Column(int x, int z, @NonNull Chunk[] chunks, @NonNull CompoundTag[] tileEntities, @NonNull CompoundTag heightMaps, int[] biomeData) {
+    public Column(int x, int z, @NonNull Chunk[] chunks, @NonNull CompoundBinaryTag[] tileEntities, @NonNull CompoundBinaryTag heightMaps, int[] biomeData) {
         if(chunks.length != 16) {
             throw new IllegalArgumentException("Chunk array length must be 16.");
         }
@@ -28,7 +28,7 @@ public class Column {
         this.z = z;
         this.chunks = Arrays.copyOf(chunks, chunks.length);
         this.biomeData = biomeData != null ? Arrays.copyOf(biomeData, biomeData.length) : null;
-        this.tileEntities = tileEntities != null ? tileEntities : new CompoundTag[0];
+        this.tileEntities = tileEntities != null ? tileEntities : new CompoundBinaryTag[0];
         this.heightMaps = heightMaps;
     }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/metadata/EntityMetadata.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/metadata/EntityMetadata.java
@@ -7,12 +7,12 @@ import com.github.steveice10.mc.protocol.data.game.world.block.BlockFace;
 import com.github.steveice10.mc.protocol.data.game.world.particle.Particle;
 import com.github.steveice10.mc.protocol.data.game.world.particle.ParticleData;
 import com.github.steveice10.mc.protocol.data.game.world.particle.ParticleType;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NonNull;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 import net.kyori.adventure.text.Component;
 
 import java.io.IOException;
@@ -175,7 +175,7 @@ public class EntityMetadata {
                     out.writeVarInt((int) meta.getValue());
                     break;
                 case NBT_TAG:
-                    NBT.write(out, (CompoundTag) meta.getValue());
+                    NBT.write(out, (CompoundBinaryTag) meta.getValue());
                     break;
                 case PARTICLE:
                     Particle particle = (Particle) meta.getValue();

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/metadata/ItemStack.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/entity/metadata/ItemStack.java
@@ -1,11 +1,11 @@
 package com.github.steveice10.mc.protocol.data.game.entity.metadata;
 
 import com.github.steveice10.mc.protocol.data.game.NBT;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.IOException;
 
@@ -14,7 +14,7 @@ import java.io.IOException;
 public class ItemStack {
     private final int id;
     private final int amount;
-    private final CompoundTag nbt;
+    private final CompoundBinaryTag nbt;
 
     public ItemStack(int id) {
         this(id, 1);

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
@@ -3,7 +3,6 @@ package com.github.steveice10.mc.protocol.packet.ingame.server;
 import com.github.steveice10.mc.protocol.data.MagicValues;
 import com.github.steveice10.mc.protocol.data.game.NBT;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
@@ -12,7 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.Setter;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.IOException;
 
@@ -29,8 +28,8 @@ public class ServerJoinGamePacket implements Packet {
     private GameMode previousGamemode;
     private int worldCount;
     private @NonNull String[] worldNames;
-    private @NonNull CompoundTag dimensionCodec;
-    private @NonNull CompoundTag dimension;
+    private @NonNull CompoundBinaryTag dimensionCodec;
+    private @NonNull CompoundBinaryTag dimension;
     private @NonNull String worldName;
     private long hashedSeed;
     private int maxPlayers;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerJoinGamePacket.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.Setter;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.IOException;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
@@ -3,7 +3,6 @@ package com.github.steveice10.mc.protocol.packet.ingame.server;
 import com.github.steveice10.mc.protocol.data.MagicValues;
 import com.github.steveice10.mc.protocol.data.game.NBT;
 import com.github.steveice10.mc.protocol.data.game.entity.player.GameMode;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
@@ -12,7 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
-import lombok.Setter;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.IOException;
 
@@ -21,7 +20,7 @@ import java.io.IOException;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class ServerRespawnPacket implements Packet {
-    private @NonNull CompoundTag dimension;
+    private @NonNull CompoundBinaryTag dimension;
     private @NonNull String worldName;
     private long hashedSeed;
     private @NonNull GameMode gamemode;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/ServerRespawnPacket.java
@@ -11,6 +11,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import lombok.Setter;
 import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.IOException;

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerChunkDataPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerChunkDataPacket.java
@@ -3,7 +3,6 @@ package com.github.steveice10.mc.protocol.packet.ingame.server.world;
 import com.github.steveice10.mc.protocol.data.game.NBT;
 import com.github.steveice10.mc.protocol.data.game.chunk.Chunk;
 import com.github.steveice10.mc.protocol.data.game.chunk.Column;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.io.stream.StreamNetInput;
@@ -15,6 +14,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -33,7 +33,7 @@ public class ServerChunkDataPacket implements Packet {
         int z = in.readInt();
         boolean fullChunk = in.readBoolean();
         int chunkMask = in.readVarInt();
-        CompoundTag heightMaps = NBT.read(in);
+        CompoundBinaryTag heightMaps = NBT.read(in);
         int[] biomeData = fullChunk ? new int[in.readVarInt()] : null;
         if (fullChunk) {
             for (int index = 0; index < biomeData.length; index++) {
@@ -50,7 +50,7 @@ public class ServerChunkDataPacket implements Packet {
             }
         }
 
-        CompoundTag[] tileEntities = new CompoundTag[in.readVarInt()];
+        CompoundBinaryTag[] tileEntities = new CompoundBinaryTag[in.readVarInt()];
         for(int i = 0; i < tileEntities.length; i++) {
             tileEntities[i] = NBT.read(in);
         }
@@ -89,7 +89,7 @@ public class ServerChunkDataPacket implements Packet {
         out.writeVarInt(dataBytes.size());
         out.writeBytes(dataBytes.toByteArray(), dataBytes.size());
         out.writeVarInt(this.column.getTileEntities().length);
-        for(CompoundTag tag : this.column.getTileEntities()) {
+        for(CompoundBinaryTag tag : this.column.getTileEntities()) {
             NBT.write(out, tag);
         }
     }

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerNBTResponsePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerNBTResponsePacket.java
@@ -1,7 +1,6 @@
 package com.github.steveice10.mc.protocol.packet.ingame.server.world;
 
 import com.github.steveice10.mc.protocol.data.game.NBT;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
@@ -11,6 +10,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.IOException;
 
@@ -20,7 +20,7 @@ import java.io.IOException;
 @AllArgsConstructor
 public class ServerNBTResponsePacket implements Packet {
     private int transactionId;
-    private @NonNull CompoundTag nbt;
+    private @NonNull CompoundBinaryTag nbt;
 
     @Override
     public void read(NetInput in) throws IOException {

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateTileEntityPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerUpdateTileEntityPacket.java
@@ -4,7 +4,6 @@ import com.github.steveice10.mc.protocol.data.MagicValues;
 import com.github.steveice10.mc.protocol.data.game.NBT;
 import com.github.steveice10.mc.protocol.data.game.entity.metadata.Position;
 import com.github.steveice10.mc.protocol.data.game.world.block.UpdatedTileType;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
 import com.github.steveice10.packetlib.io.NetInput;
 import com.github.steveice10.packetlib.io.NetOutput;
 import com.github.steveice10.packetlib.packet.Packet;
@@ -14,6 +13,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.Setter;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 
 import java.io.IOException;
 
@@ -24,7 +24,7 @@ import java.io.IOException;
 public class ServerUpdateTileEntityPacket implements Packet {
     private @NonNull Position position;
     private @NonNull UpdatedTileType type;
-    private @NonNull CompoundTag nbt;
+    private @NonNull CompoundBinaryTag nbt;
 
     @Override
     public void read(NetInput in) throws IOException {

--- a/src/test/java/com/github/steveice10/mc/protocol/MinecraftProtocolTest.java
+++ b/src/test/java/com/github/steveice10/mc/protocol/MinecraftProtocolTest.java
@@ -8,12 +8,6 @@ import com.github.steveice10.mc.protocol.data.status.VersionInfo;
 import com.github.steveice10.mc.protocol.data.status.handler.ServerInfoBuilder;
 import com.github.steveice10.mc.protocol.data.status.handler.ServerInfoHandler;
 import com.github.steveice10.mc.protocol.packet.ingame.server.ServerJoinGamePacket;
-import com.github.steveice10.opennbt.tag.builtin.ByteTag;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
-import com.github.steveice10.opennbt.tag.builtin.FloatTag;
-import com.github.steveice10.opennbt.tag.builtin.IntTag;
-import com.github.steveice10.opennbt.tag.builtin.ListTag;
-import com.github.steveice10.opennbt.tag.builtin.StringTag;
 import com.github.steveice10.packetlib.Client;
 import com.github.steveice10.packetlib.Server;
 import com.github.steveice10.packetlib.Session;
@@ -22,6 +16,11 @@ import com.github.steveice10.packetlib.event.session.PacketReceivedEvent;
 import com.github.steveice10.packetlib.event.session.SessionAdapter;
 import com.github.steveice10.packetlib.packet.Packet;
 import com.github.steveice10.packetlib.tcp.TcpSessionFactory;
+import net.kyori.adventure.nbt.ByteBinaryTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
+import net.kyori.adventure.nbt.FloatBinaryTag;
+import net.kyori.adventure.nbt.IntBinaryTag;
+import net.kyori.adventure.nbt.StringBinaryTag;
 import net.kyori.adventure.text.Component;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -146,31 +145,28 @@ public class MinecraftProtocolTest {
         }
     }
 
-    private static CompoundTag getDimensionTag() {
-        CompoundTag tag = new CompoundTag("");
-        ListTag dimensionTag = new ListTag("dimension");
-        CompoundTag overworldTag = getOverworldTag();
-        dimensionTag.add(overworldTag);
-        overworldTag.put(tag);
-        return tag;
+    private static CompoundBinaryTag getDimensionTag() {
+        return CompoundBinaryTag.builder()
+                .put("dimension", getOverworldTag())
+                .build();
     }
 
-    private static CompoundTag getOverworldTag() {
-        CompoundTag overworldTag = new CompoundTag("");
-        overworldTag.put(new StringTag("name", "minecraft:overworld"));
-        overworldTag.put(new ByteTag("piglin_safe", (byte) 0));
-        overworldTag.put(new ByteTag("natural", (byte) 1));
-        overworldTag.put(new FloatTag("ambient_light", 0f));
-        overworldTag.put(new StringTag("infiniburn", "minecraft:infiniburn_overworld"));
-        overworldTag.put(new ByteTag("respawn_anchor_works", (byte) 0));
-        overworldTag.put(new ByteTag("has_skylight", (byte) 1));
-        overworldTag.put(new ByteTag("bed_works", (byte) 1));
-        overworldTag.put(new StringTag("effects", "minecraft:overworld"));
-        overworldTag.put(new ByteTag("has_raids", (byte) 1));
-        overworldTag.put(new IntTag("logical_height", 256));
-        overworldTag.put(new FloatTag("coordinate_scale", 1f));
-        overworldTag.put(new ByteTag("ultrawarm", (byte) 0));
-        overworldTag.put(new ByteTag("has_ceiling", (byte) 0));
+    private static CompoundBinaryTag getOverworldTag() {
+        CompoundBinaryTag overworldTag = CompoundBinaryTag.empty();
+        overworldTag.put("name", StringBinaryTag.of("minecraft:overworld"));
+        overworldTag.put("piglin_safe", ByteBinaryTag.of((byte) 0));
+        overworldTag.put("natural", ByteBinaryTag.of((byte)  1));
+        overworldTag.put("ambient_light", FloatBinaryTag.of(0f));
+        overworldTag.put("infiniburn", StringBinaryTag.of("minecraft:infiniburn_overworld"));
+        overworldTag.put("respawn_anchor_works", ByteBinaryTag.of((byte) 0));
+        overworldTag.put("has_skylight", ByteBinaryTag.of((byte) 1));
+        overworldTag.put("bed_works", ByteBinaryTag.of((byte) 1));
+        overworldTag.put("effects", StringBinaryTag.of("minecraft:overworld"));
+        overworldTag.put("has_raids", ByteBinaryTag.of((byte) 1));
+        overworldTag.put("logical_height", IntBinaryTag.of(256));
+        overworldTag.put("coordinate_scale", FloatBinaryTag.of(1f));
+        overworldTag.put("ultrawarm", ByteBinaryTag.of((byte) 0));
+        overworldTag.put("has_ceiling", ByteBinaryTag.of((byte) 0));
         return overworldTag;
     }
 }

--- a/src/test/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerChunkDataPacketTest.java
+++ b/src/test/java/com/github/steveice10/mc/protocol/packet/ingame/server/world/ServerChunkDataPacketTest.java
@@ -3,7 +3,7 @@ package com.github.steveice10.mc.protocol.packet.ingame.server.world;
 import com.github.steveice10.mc.protocol.data.game.chunk.Chunk;
 import com.github.steveice10.mc.protocol.data.game.chunk.Column;
 import com.github.steveice10.mc.protocol.packet.PacketTest;
-import com.github.steveice10.opennbt.tag.builtin.CompoundTag;
+import net.kyori.adventure.nbt.CompoundBinaryTag;
 import org.junit.Before;
 
 public class ServerChunkDataPacketTest extends PacketTest {
@@ -17,15 +17,15 @@ public class ServerChunkDataPacketTest extends PacketTest {
                         new Column(0, 0, new Chunk[] {
                                 null, null, null, null, null, null, null, chunk,
                                 null, chunk, null, null, null, chunk, null, null
-                        }, new CompoundTag[0], new CompoundTag("HeightMaps"))
+                        }, new CompoundBinaryTag[0], CompoundBinaryTag.empty())
                 ),
                 new ServerChunkDataPacket(
                         new Column(1, 1, new Chunk[] {
                                 chunk, chunk, chunk, chunk, chunk, chunk, chunk, chunk,
                                 chunk, chunk, chunk, chunk, chunk, chunk, chunk, chunk
-                        }, new CompoundTag[] {
-                                new CompoundTag("TileEntity")
-                        }, new CompoundTag("HeightMaps"), new int[1024])
+                        }, new CompoundBinaryTag[] {
+                                CompoundBinaryTag.empty()
+                        }, CompoundBinaryTag.empty(), new int[1024])
                 )
         );
     }


### PR DESCRIPTION
[Adventure](https://github.com/KyoriPowered/adventure) has not only become the de facto standard API for chat components, it also sports a great [NBT library](https://github.com/KyoriPowered/adventure/tree/master/nbt).

This PR replaces OpenNBT with adventure-nbt to seek using a standardized NBT API across all projects.

This PR is not ready for merging yet. 