### PR TITLE
Fixed parsing of the MOTD as Component

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>net.kyori</groupId>
             <artifactId>adventure-text-serializer-gson</artifactId>
-            <version>4.2.0</version>
+            <version>4.7.0</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/status/server/StatusResponsePacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/status/server/StatusResponsePacket.java
@@ -53,7 +53,7 @@ public class StatusResponsePacket implements Packet {
 
         PlayerInfo players = new PlayerInfo(plrs.get("max").getAsInt(), plrs.get("online").getAsInt(), profiles);
         JsonElement desc = obj.get("description");
-        Component description = DefaultComponentSerializer.get().deserialize(desc.toString());
+        Component description = DefaultComponentSerializer.get().serializer().fromJson(desc, Component.class);
         byte[] icon = null;
         if(obj.has("favicon")) {
             icon = this.stringToIcon(obj.get("favicon").getAsString());


### PR DESCRIPTION
When the change to handling the MOTD as Adventure components was implemented, there seemed to have been a tiny mistake on how things were being parsed. 

I noticed this when I was updating one of my personal projects that uses MCProtocolLib as a dependency.

Below are some examples of how the MOTD looked before switching to Adventure and after.
Before: https://paste.gg/p/anonymous/47f169ede38d453e80ca7338acc9c4c7
After: https://paste.gg/p/anonymous/037d5fad36704d5ca67a8b59cbcdaa28

The main thing to notice here is the MOTD section. As you can see in the before, the raw and formatted are cleanly done with not much extra whitespace. After updating to a version of MCProtocolLib that used Adventure, the output looked like the after post, which instantly caught my eye that something was off. After doing some digging, it turns out the issue was that the MOTD was being converted to a string directory from the JsonElement. This caused some double parsing to go on and have some escape character problems as you also saw in the after post. This PR fixes how the MOTD is being parsed and returns it back to normal. Below, I have linked another paste which shows what my PR changes and you can see how the MOTD section looks back normal.

This PR: https://paste.gg/p/anonymous/ae1929ab813a47b4aa1ec5011ddc99b7