### PR TITLE
Changing the deprecated dependency

### DIFF
--- a/src/test/java/com/github/steveice10/mc/protocol/data/MagicValuesTest.java
+++ b/src/test/java/com/github/steveice10/mc/protocol/data/MagicValuesTest.java
@@ -100,8 +100,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
 
 public class MagicValuesTest {
     private Map<Class<? extends Enum<?>>, List<Class<?>>> typeMappings = new HashMap<>();


### PR DESCRIPTION
Changing the deprecated dependency

https://javadoc.io/static/junit/junit/4.13.2/org/junit/Assert.html#assertThat(java.lang.String,%20T,%20org.hamcrest.Matcher)