### PR TITLE
Updated Lombok to fix broken compilation when using Java 16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.12</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I was unable to compile using JDK 16 due to an issue with Lombok. [This StackOverflow answer](https://stackoverflow.com/a/66981165/9665770) describes the solution. Further details in https://github.com/projectlombok/lombok/issues/2681 (linked in the answer).