### PR TITLE
Fix the example to send the right tags for 1.18

### DIFF
--- a/example/com/github/steveice10/mc/protocol/test/MinecraftProtocolTest.java
+++ b/example/com/github/steveice10/mc/protocol/test/MinecraftProtocolTest.java
@@ -261,6 +261,8 @@ public class MinecraftProtocolTest {
         overworldTag.put(new FloatTag("coordinate_scale", 1f));
         overworldTag.put(new ByteTag("ultrawarm", (byte) 0));
         overworldTag.put(new ByteTag("has_ceiling", (byte) 0));
+        overworldTag.put(new IntTag("height", 256));
+        overworldTag.put(new IntTag("min_y", 0));
         return overworldTag;
     }
 


### PR DESCRIPTION
Not properly tested, but I when I based some code on parts of this I had to send these tags to make it work