### PR TITLE
Fix resizing a singleton palette

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
@@ -137,10 +137,7 @@ public class DataPalette {
         this.storage = new BitStorage(bitsPerEntry, paletteType.getStorageSize());
 
         if (oldPalette instanceof SingletonPalette) {
-            for (int i = 0; i < paletteType.getStorageSize(); i++) {
-                // TODO necessary?
-                this.storage.set(i, 0);
-            }
+            this.palette.stateToId(oldPalette.idToState(0));
         } else {
             for (int i = 0; i < paletteType.getStorageSize(); i++) {
                 this.storage.set(i, this.palette.stateToId(oldPalette.idToState(oldData.get(i))));


### PR DESCRIPTION
The current method accomplishes nothing because everything is already set to 0 in the data array.  I've replaced it with a method that sets the ID of 0 to point to whatever the singleton palette was pointing at before.

Implemented and tested with the nearly identical system PacketEvents 2.0 to be working - as I've copied and pasted over many of these classes.

Without this fix, the first block that is set in this resized singleton palette becomes the identity of every single block in that chunk section - which is quite bad.