### PR TITLE
Fixed: Added missing MoveToHotbarAction value for the swap with off-hand inventory action.

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/MagicValues.java
@@ -140,6 +140,7 @@ public class MagicValues {
         register(MoveToHotbarAction.SLOT_7, 6);
         register(MoveToHotbarAction.SLOT_8, 7);
         register(MoveToHotbarAction.SLOT_9, 8);
+        register(MoveToHotbarAction.OFF_HAND, 40);
 
         register(CreativeGrabAction.GRAB, 2);
 

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/inventory/MoveToHotbarAction.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/inventory/MoveToHotbarAction.java
@@ -9,5 +9,6 @@ public enum MoveToHotbarAction implements ContainerAction {
     SLOT_6,
     SLOT_7,
     SLOT_8,
-    SLOT_9;
+    SLOT_9,
+    OFF_HAND;
 }


### PR DESCRIPTION
This inventory action is triggered when a player has their inventory open and clicks on some slot with the `F` key.
This case is also documented here: https://wiki.vg/Protocol#Click_Window

I noticed this because client sessions in a simple private Minecraft server proxy that uses this library were silently (without stack trace or anything) closed whenever the player uses this inventory action. Adding this MoveToHotbarAction value was confirmed to resolve the issue.