### PR TITLE
Change modifier of setState method

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/MinecraftProtocol.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/MinecraftProtocol.java
@@ -170,7 +170,7 @@ public class MinecraftProtocol extends PacketProtocol {
         return this.state;
     }
 
-    protected void setState(ProtocolState state) {
+    public void setState(ProtocolState state) {
         this.state = state;
         this.stateCodec = this.codec.getCodec(state);
     }


### PR DESCRIPTION
I'm using MCProtocolLib in a project where I only require the actual wrappers. To be able to get packets from an ID, I need to manually set the state of the MinecraftProtocol.