### PR TITLE
Fix 1.19.1 ClientboundPlayerInfoPacket serialization

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/ClientboundPlayerInfoPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/ClientboundPlayerInfoPacket.java
@@ -146,6 +146,7 @@ public class ClientboundPlayerInfoPacket implements MinecraftPacket {
                         helper.writeString(out, DefaultComponentSerializer.get().serialize(entry.getDisplayName()));
                     }
 
+                    out.writeBoolean(entry.getPublicKey() != null);
                     if (entry.getPublicKey() != null) {
                         out.writeLong(entry.getExpiresAt());
                         byte[] encoded = entry.getPublicKey().getEncoded();


### PR DESCRIPTION
A boolean should be written, whether public key and signature are present.

See https://wiki.vg/Protocol#Player_Info "Has Sig Data"

See https://github.com/GeyserMC/MCProtocolLib/blob/master/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/ClientboundPlayerInfoPacket.java#L75 for corresponding deserialization of this boolean

Should fix "io.netty.handler.codec.DecoderException: java.io.IOException: Packet 0/55 (vj) was larger than I expected, found ... bytes extra whilst reading packet 55" in vanilla Minecraft 1.19.1 Client.