### PR TITLE
Fix misreading of ternary in a8788fb

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chat/MessageSignature.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chat/MessageSignature.java
@@ -16,10 +16,10 @@ public class MessageSignature {
         int id = helper.readVarInt(in) - 1;
         byte[] messageSignature;
         if (id == -1) {
-            messageSignature = null;
-        } else {
             messageSignature = new byte[256];
             in.readBytes(messageSignature);
+        } else {
+            messageSignature = null;
         }
         return new MessageSignature(id, messageSignature);
     }


### PR DESCRIPTION
@Camotoy I believe you misread the intent of the ternary [here](https://github.com/GeyserMC/MCProtocolLib/commit/a8788fb899343d902c3998c86b329ee551d4dcda#diff-6a96300165ea0b5a0c5fb6be816b13cb50aca8f0d2f1a8944708a3920838808eL57) in a8788fb which has broken secure chat.