### PR TITLE
Update hardcoded Block Ids in ClientboundBlockEventPacket

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/level/ClientboundBlockEventPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/level/ClientboundBlockEventPacket.java
@@ -16,17 +16,17 @@ import lombok.With;
 @AllArgsConstructor
 public class ClientboundBlockEventPacket implements MinecraftPacket {
     // Do we really want these hardcoded values?
-    private static final int NOTE_BLOCK = 93;
-    private static final int STICKY_PISTON = 112;
-    private static final int PISTON = 119;
-    private static final int MOB_SPAWNER = 165;
-    private static final int CHEST = 167;
-    private static final int ENDER_CHEST = 328;
-    private static final int TRAPPED_CHEST = 392;
-    private static final int END_GATEWAY = 576;
-    private static final int SHULKER_BOX_LOWER = 586;
-    private static final int SHULKER_BOX_HIGHER = 602;
-    private static final int BELL = 755;
+    private static final int NOTE_BLOCK = 101;
+    private static final int STICKY_PISTON = 120;
+    private static final int PISTON = 127;
+    private static final int MOB_SPAWNER = 174;
+    private static final int CHEST = 176;
+    private static final int ENDER_CHEST = 343;
+    private static final int TRAPPED_CHEST = 410;
+    private static final int END_GATEWAY = 600;
+    private static final int SHULKER_BOX_LOWER = 610;
+    private static final int SHULKER_BOX_HIGHER = 626;
+    private static final int BELL = 779;
 
     private final @NonNull Vector3i position;
     private final @NonNull BlockValueType type;


### PR DESCRIPTION
Needed to resolve https://github.com/GeyserMC/Geyser/issues/3624
Crudely generated with the following code in Geyser.
```java
List<String> blocks = Arrays.asList(BlockRegistries.CLEAN_JAVA_IDENTIFIERS.get());
Object2IntMap<String> ids = new Object2IntLinkedOpenHashMap<>();
ids.put("NOTE_BLOCK", blocks.indexOf("minecraft:note_block"));
ids.put("STICKY_PISTON", blocks.indexOf("minecraft:sticky_piston"));
ids.put("PISTON", blocks.indexOf("minecraft:piston"));
ids.put("MOB_SPAWNER", blocks.indexOf("minecraft:spawner"));
ids.put("CHEST", blocks.indexOf("minecraft:chest"));
ids.put("ENDER_CHEST", blocks.indexOf("minecraft:ender_chest"));
ids.put("TRAPPED_CHEST", blocks.indexOf("minecraft:trapped_chest"));
ids.put("END_GATEWAY", blocks.indexOf("minecraft:end_gateway"));
ids.put("SHULKER_BOX_LOWER", blocks.indexOf("minecraft:shulker_box"));
ids.put("SHULKER_BOX_HIGHER", blocks.indexOf("minecraft:black_shulker_box"));
ids.put("BELL", blocks.indexOf("minecraft:bell"));
ids.forEach((field, id) -> System.out.println("private static final int " + field + " = " + id + ";"));
```