### PR TITLE
Fix rain when set by GameEvent directly

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/level/notify/GameEvent.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/level/notify/GameEvent.java
@@ -2,8 +2,8 @@ package com.github.steveice10.mc.protocol.data.game.level.notify;
 
 public enum GameEvent {
     INVALID_BED,
-    START_RAIN,
     STOP_RAIN,
+    START_RAIN,
     CHANGE_GAMEMODE,
     ENTER_CREDITS,
     DEMO_MESSAGE,


### PR DESCRIPTION
Should fix https://github.com/GeyserMC/Geyser/issues/3611

As documented on the protocol wiki, stop rain (1) should come before start rain (2) https://wiki.vg/Protocol#Game_Event. Initially I thought that this could be related to our handling of rain strength (7) (see https://github.com/GeyserMC/Geyser/blob/master/core/src/main/java/org/geysermc/geyser/translator/protocol/java/level/JavaGameEventTranslator.java#L72-L87). In fact, that code was working so well that it was masking this issue entirely.

For context, this issue was primarily experienced when the weather lock flag was set to clear with world guard. In this scenario, only a single Game Event packet is sent to set the weather to clear. But given we had these switched, it would instead lead to endless rain for the Bedrock Client.

In contrast, the Vanilla weather command gave the appearance of working fine. It only appeared this way, however, because the rain strength logic effectively ends up overriding the initial packet sent that indicates clear weather to the bedrock client. These are sent because vanilla will send multiple rain strength packets that ramp up in strength, as well as ramp down in strength when the weather is cleared.