### PR TITLE
fix(sec): upgrade io.netty:netty-codec-haproxy to 4.1.86.final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,7 +144,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-haproxy</artifactId>
-            <version>4.1.66.Final</version>
+            <version>4.1.86.final</version>
             <scope>compile</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in io.netty:netty-codec-haproxy 4.1.66.Final
- [CVE-2022-41881](https://www.oscs1024.com/hd/CVE-2022-41881)


### What did I do？
Upgrade io.netty:netty-codec-haproxy from 4.1.66.Final to 4.1.86.final for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS