### PR TITLE
Fix serialization of ClientboundCommandsPacket for command types RESO…

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/ClientboundCommandsPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/ClientboundCommandsPacket.java
@@ -308,8 +308,10 @@ public class ClientboundCommandsPacket implements MinecraftPacket {
                     case TIME:
                         out.writeInt(((TimeProperties) node.getProperties()).getMin());
                         break;
-                    case RESOURCE:
                     case RESOURCE_OR_TAG:
+                    case RESOURCE_OR_TAG_KEY:
+                    case RESOURCE:
+                    case RESOURCE_KEY:
                         helper.writeString(out, ((ResourceProperties) node.getProperties()).getRegistryKey());
                         break;
                     default:


### PR DESCRIPTION
…URCE_OR_TAG_KEY and RESOURCE_KEY.

Found this bug on serializing ClientboundCommandsPacket.  Simple fix.