### PR TITLE
expose the shutdown method of the event loop group

### DIFF
--- a/src/main/java/com/github/steveice10/packetlib/tcp/TcpClientSession.java
+++ b/src/main/java/com/github/steveice10/packetlib/tcp/TcpClientSession.java
@@ -316,6 +316,20 @@ public class TcpClientSession extends TcpSession {
                 break;
         }
 
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> EVENT_LOOP_GROUP.shutdownGracefully()));
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> shutdownEventLoopGroup()));
+    }
+
+    public static void shutdownEventLoopGroup() {
+        if (EVENT_LOOP_GROUP != null) {
+            try {
+                EVENT_LOOP_GROUP.shutdownGracefully().sync();
+                EVENT_LOOP_GROUP = null;
+                CHANNEL_CLASS = null;
+                DATAGRAM_CHANNEL_CLASS = null;
+            } catch (InterruptedException e) {
+               e.printStackTrace();
+            }
+
+        }
     }
 }


### PR DESCRIPTION
To exit normally all non-daemon threads of the java process are supposed to have stopped. TcpClientSession creates an static class member EventLoopGroup which in turn instantiates worker threads. These need to be stopped as a part of shutting down the server.

This patch exposes the shutdown of the EventLoopGroup as a static function intended to be called by some central function as a part of server shutdwon.
