### PR TITLE
Fix ClientboundLoginPacket serialization

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/ClientboundLoginPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/ClientboundLoginPacket.java
@@ -71,7 +71,7 @@ public class ClientboundLoginPacket implements MinecraftPacket {
         out.writeInt(this.entityId);
         out.writeBoolean(this.hardcore);
         out.writeByte(this.gameMode.ordinal());
-        out.writeByte(GameMode.toNullableId(this.gameMode));
+        out.writeByte(GameMode.toNullableId(this.previousGamemode));
         helper.writeVarInt(out, this.worldNames.length);
         for (String worldName : this.worldNames) {
             helper.writeString(out, worldName);


### PR DESCRIPTION
The byte written after the gamemode should be the previous gamemode. The serialization now matches the deserialization.