### PR TITLE
Implement deep copies for Chunk Sections

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/BitStorage.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/BitStorage.java
@@ -1,12 +1,11 @@
 package com.github.steveice10.mc.protocol.data.game.chunk;
 
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NonNull;
+import lombok.*;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Arrays;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class BitStorage {
     private static final int[] MAGIC_VALUES = {
@@ -75,6 +74,11 @@ public class BitStorage {
         this.divideMultiply = Integer.toUnsignedLong(MAGIC_VALUES[magicIndex]);
         this.divideAdd = Integer.toUnsignedLong(MAGIC_VALUES[magicIndex + 1]);
         this.divideShift = MAGIC_VALUES[magicIndex + 2];
+    }
+
+    public BitStorage(BitStorage original) {
+        this(Arrays.copyOf(original.data, original.data.length), original.bitsPerEntry, original.size,
+                original.maxValue, original.valuesPerLong, original.divideMultiply, original.divideAdd, original.divideShift);
     }
 
     public int get(int index) {

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/ChunkSection.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/ChunkSection.java
@@ -19,6 +19,10 @@ public class ChunkSection {
         this(0, DataPalette.createForChunk(), DataPalette.createForBiome(4));
     }
 
+    public ChunkSection(ChunkSection original) {
+        this(original.blockCount, new DataPalette(original.chunkData), new DataPalette(original.biomeData));
+    }
+
     public int getBlock(int x, int y, int z) {
         return this.chunkData.get(x, y, z);
     }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
@@ -16,6 +16,10 @@ public class DataPalette {
     private final PaletteType paletteType;
     private final int globalPaletteBits;
 
+    public DataPalette(DataPalette original) {
+        this(original.palette.copy(), original.storage == null ? null : new BitStorage(original.storage), original.paletteType, original.globalPaletteBits);
+    }
+
     public static DataPalette createForChunk() {
         return createForChunk(GLOBAL_PALETTE_BITS_PER_ENTRY);
     }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/GlobalPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/GlobalPalette.java
@@ -23,4 +23,9 @@ public class GlobalPalette implements Palette {
     public int idToState(int id) {
         return id;
     }
+
+    @Override
+    public GlobalPalette copy() {
+        return this;
+    }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/ListPalette.java
@@ -2,16 +2,20 @@ package com.github.steveice10.mc.protocol.data.game.chunk.palette;
 
 import com.github.steveice10.mc.protocol.codec.MinecraftCodecHelper;
 import io.netty.buffer.ByteBuf;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * A palette backed by a List.
  */
 @Getter
 @EqualsAndHashCode
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ListPalette implements Palette {
     private final int maxId;
 
@@ -64,5 +68,10 @@ public class ListPalette implements Palette {
         } else {
             return 0;
         }
+    }
+
+    @Override
+    public ListPalette copy() {
+        return new ListPalette(this.maxId, Arrays.copyOf(this.data, this.data.length), this.nextId);
     }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/MapPalette.java
@@ -4,13 +4,17 @@ import com.github.steveice10.mc.protocol.codec.MinecraftCodecHelper;
 import io.netty.buffer.ByteBuf;
 import io.netty.util.collection.IntObjectHashMap;
 import io.netty.util.collection.IntObjectMap;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 /**
  * A palette backed by a map.
  */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class MapPalette implements Palette {
     private final int maxId;
@@ -65,5 +69,12 @@ public class MapPalette implements Palette {
         } else {
             return 0;
         }
+    }
+
+    @Override
+    public MapPalette copy() {
+        MapPalette mapPalette = new MapPalette(this.maxId, Arrays.copyOf(this.idToState, this.idToState.length), this.nextId);
+        mapPalette.stateToId.putAll(this.stateToId);
+        return mapPalette;
     }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/Palette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/Palette.java
@@ -18,7 +18,7 @@ public interface Palette {
      * @param state Block state to convert.
      * @return The resulting storage ID.
      */
-    public int stateToId(int state);
+    int stateToId(int state);
 
     /**
      * Converts a storage ID to a block state. If the storage ID has no mapping,
@@ -27,5 +27,12 @@ public interface Palette {
      * @param id Storage ID to convert.
      * @return The resulting block state.
      */
-    public int idToState(int id);
+    int idToState(int id);
+
+    /**
+     * Creates a copy of this palette.
+     * This performs a deep copy of the palette's internal data.
+     * @return The palette's copy.
+     */
+    Palette copy();
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/SingletonPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/palette/SingletonPalette.java
@@ -33,4 +33,9 @@ public class SingletonPalette implements Palette {
         }
         return 0;
     }
+
+    @Override
+    public SingletonPalette copy() {
+        return this;
+    }
 }

--- a/src/test/java/com/github/steveice10/mc/protocol/data/ChunkTest.java
+++ b/src/test/java/com/github/steveice10/mc/protocol/data/ChunkTest.java
@@ -52,4 +52,15 @@ public class ChunkTest {
             Assert.assertEquals("Decoded packet does not match original: " + section + " vs " + decoded, section, decoded);
         }
     }
+
+    @Test
+    public void testDeepCopy() {
+        for (ChunkSection section : chunkSectionsToTest) {
+            ChunkSection copy = new ChunkSection(section);
+            Assert.assertEquals("Deep copy does not match original: " + section + " vs " + copy, section, copy);
+
+            copy.setBlock(1, 1, 1, 10);
+            Assert.assertNotEquals("Deep copy is not deep: " + section + " vs " + copy, section, copy);
+        }
+    }
 }


### PR DESCRIPTION
I personally need such a feature for one of my projects and accessing all those fields using reflection would be super tedious. Right now I serialize and deserialize the Chunk Section im my code instead of cloning it using reflection, so this is a lot better than that.