### PR TITLE
Cleanup and fix nullabilities in custom payload/query packets

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/common/clientbound/ClientboundCustomPayloadPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/common/clientbound/ClientboundCustomPayloadPacket.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 @AllArgsConstructor
 public class ClientboundCustomPayloadPacket implements MinecraftPacket {
     private final @NonNull String channel;
-    private final @NonNull byte[] data;
+    private final byte @NonNull[] data;
 
     public ClientboundCustomPayloadPacket(ByteBuf in, MinecraftCodecHelper helper) throws IOException {
         this.channel = helper.readString(in);

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/common/serverbound/ServerboundCustomPayloadPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/common/serverbound/ServerboundCustomPayloadPacket.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 @AllArgsConstructor
 public class ServerboundCustomPayloadPacket implements MinecraftPacket {
     private final @NonNull String channel;
-    private final @NonNull byte data[];
+    private final byte @NonNull[] data;
 
     public ServerboundCustomPayloadPacket(ByteBuf in, MinecraftCodecHelper helper) throws IOException {
         this.channel = helper.readString(in);

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/clientbound/ClientboundCustomQueryPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/clientbound/ClientboundCustomQueryPacket.java
@@ -16,7 +16,7 @@ import java.io.IOException;
 public class ClientboundCustomQueryPacket implements MinecraftPacket {
     private final int messageId;
     private final @NonNull String channel;
-    private final @NonNull byte[] data;
+    private final byte @NonNull[] data;
 
     public ClientboundCustomQueryPacket(ByteBuf in, MinecraftCodecHelper helper) throws IOException {
         this.messageId = helper.readVarInt(in);

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/serverbound/ServerboundCustomQueryAnswerPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/serverbound/ServerboundCustomQueryAnswerPacket.java
@@ -6,13 +6,14 @@ import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.With;
+import org.jetbrains.annotations.Nullable;
 
 @Data
 @With
 @AllArgsConstructor
 public class ServerboundCustomQueryAnswerPacket implements MinecraftPacket {
     private final int transactionId;
-    private final byte[] data;
+    private final byte @Nullable[] data;
 
     public ServerboundCustomQueryAnswerPacket(int transactionId) {
         this(transactionId, new byte[0]);
@@ -20,12 +21,12 @@ public class ServerboundCustomQueryAnswerPacket implements MinecraftPacket {
 
     public ServerboundCustomQueryAnswerPacket(ByteBuf in, MinecraftCodecHelper helper) {
         this.transactionId = helper.readVarInt(in);
-        this.data = helper.readByteArray(in, ByteBuf::readableBytes);
+        this.data = helper.readNullable(in, buf -> helper.readByteArray(buf, ByteBuf::readableBytes));
     }
 
     @Override
     public void serialize(ByteBuf out, MinecraftCodecHelper helper) {
         helper.writeVarInt(out, this.transactionId);
-        out.writeBytes(this.data);
+        helper.writeNullable(out, this.data, ByteBuf::writeBytes);
     }
 }


### PR DESCRIPTION
There was a regression in the 1.20.2 update where we dropped support for null payloads (represents a misunderstanding on the client's behalf) in ServerboundCustomQueryAnswerPacket.