### PR TITLE
Fix: Serverbound ServerboundResourcePackPacket registered as client bound

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/codec/MinecraftCodec.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/codec/MinecraftCodec.java
@@ -243,7 +243,7 @@ public class MinecraftCodec {
                     .registerServerboundPacket(ServerboundFinishConfigurationPacket.class, ServerboundFinishConfigurationPacket::new)
                     .registerServerboundPacket(ServerboundKeepAlivePacket.class, ServerboundKeepAlivePacket::new)
                     .registerServerboundPacket(ServerboundPongPacket.class, ServerboundPongPacket::new)
-                    .registerClientboundPacket(ServerboundResourcePackPacket.class, ServerboundResourcePackPacket::new)
+                    .registerServerboundPacket(ServerboundResourcePackPacket.class, ServerboundResourcePackPacket::new)
             ).state(ProtocolState.GAME, PacketStateCodec.builder()
                     .registerClientboundPacket(ClientboundDelimiterPacket.class, ClientboundDelimiterPacket::new)
                     .registerClientboundPacket(ClientboundAddEntityPacket.class, ClientboundAddEntityPacket::new)


### PR DESCRIPTION
Needed for https://github.com/GeyserMC/Geyser/compare/master...onebeastchris:Geyser:decline-resource-packs to fix timeout issues due to non rejected packs.