### PR TITLE
Read Component instead of String in ClientboundLoginDisconnectPacket

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/login/clientbound/ClientboundLoginDisconnectPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/login/clientbound/ClientboundLoginDisconnectPacket.java
@@ -22,8 +22,8 @@ public class ClientboundLoginDisconnectPacket implements MinecraftPacket {
         this(DefaultComponentSerializer.get().deserialize(text));
     }
 
-    public ClientboundLoginDisconnectPacket(ByteBuf in, MinecraftCodecHelper codecHelper) throws IOException {
-        this.reason = DefaultComponentSerializer.get().deserialize(codecHelper.readString(in));
+    public ClientboundLoginDisconnectPacket(ByteBuf in, MinecraftCodecHelper helper) throws IOException {
+        this.reason = helper.readComponent(in);
     }
 
     @Override


### PR DESCRIPTION
Should resolve issues within Geyser, such as https://github.com/GeyserMC/Geyser/issues/4049