### PR TITLE
Fix DataPalette index & deprecate unused globalPaletteBits

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
@@ -103,7 +103,7 @@ public class DataPalette {
         }
     }
 
-    private static int index(int x, int y, int z) {
-        return y << 8 | z << 4 | x;
+    private int index(int x, int y, int z) {
+        return y << paletteType.getMaxBitsPerEntry() | z << paletteType.getMinBitsPerEntry() | x;
     }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
@@ -66,8 +66,7 @@ public class DataPalette {
      */
     @Deprecated(forRemoval = true)
     public static DataPalette createEmpty(PaletteType paletteType, int globalPaletteBits) {
-        return new DataPalette(new ListPalette(paletteType.getMinBitsPerEntry()),
-                new BitStorage(paletteType.getMinBitsPerEntry(), paletteType.getStorageSize()), paletteType);
+        return createEmpty(paletteType);
     }
 
 

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/chunk/DataPalette.java
@@ -9,33 +9,67 @@ import lombok.*;
 @EqualsAndHashCode
 @ToString
 public class DataPalette {
+
+    /*
+     * @deprecated globalPaletteBits is no longer in use.
+     */
+    @Deprecated(forRemoval = true)
     public static final int GLOBAL_PALETTE_BITS_PER_ENTRY = 14;
 
     private @NonNull Palette palette;
     private BitStorage storage;
     private final PaletteType paletteType;
-    private final int globalPaletteBits;
+
+    /*
+     * @deprecated globalPaletteBits is no longer in use, use {@link #DataPalette(Palette, BitStorage, PaletteType)} instead.
+     */
+    @Deprecated(forRemoval = true)
+    public DataPalette(@NonNull Palette palette, BitStorage storage, PaletteType paletteType, int globalPaletteBits) {
+        this(palette, storage, paletteType);
+    }
 
     public DataPalette(DataPalette original) {
-        this(original.palette.copy(), original.storage == null ? null : new BitStorage(original.storage), original.paletteType, original.globalPaletteBits);
+        this(original.palette.copy(), original.storage == null ? null : new BitStorage(original.storage), original.paletteType);
     }
 
     public static DataPalette createForChunk() {
-        return createForChunk(GLOBAL_PALETTE_BITS_PER_ENTRY);
+        return createEmpty(PaletteType.CHUNK);
     }
 
+    /*
+     * @deprecated globalPaletteBits is no longer in use, use {@link #createForChunk()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static DataPalette createForChunk(int globalPaletteBits) {
-        return createEmpty(PaletteType.CHUNK, globalPaletteBits);
+        return createForChunk();
     }
 
+    /*
+     * @deprecated globalPaletteBits is no longer in use, use {@link #createForBiome()} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static DataPalette createForBiome(int globalPaletteBits) {
-        return createEmpty(PaletteType.BIOME, globalPaletteBits);
+        return createForBiome();
     }
 
+    public static DataPalette createForBiome() {
+        return createEmpty(PaletteType.BIOME);
+    }
+
+    public static DataPalette createEmpty(PaletteType paletteType) {
+        return new DataPalette(new ListPalette(paletteType.getMinBitsPerEntry()),
+                new BitStorage(paletteType.getMinBitsPerEntry(), paletteType.getStorageSize()), paletteType);
+    }
+
+    /*
+     * @deprecated globalPaletteBits is no longer in use, use {@link #createEmpty(PaletteType)} instead.
+     */
+    @Deprecated(forRemoval = true)
     public static DataPalette createEmpty(PaletteType paletteType, int globalPaletteBits) {
         return new DataPalette(new ListPalette(paletteType.getMinBitsPerEntry()),
-                new BitStorage(paletteType.getMinBitsPerEntry(), paletteType.getStorageSize()), paletteType, globalPaletteBits);
+                new BitStorage(paletteType.getMinBitsPerEntry(), paletteType.getStorageSize()), paletteType);
     }
+
 
     public int get(int x, int y, int z) {
         if (storage != null) {


### PR DESCRIPTION
This PR attempts to fix #774 

From my basic testing, the block palettes still work as they did before without any issues and biome palettes do not throw any errors anymore. They also seem correct in game, but don't quote me on that. (Since my test world is very small with not that many different biomes (2 to be exact))
