### PR TITLE
Fix ClientboundSetTitleTextPacket serialization

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/title/ClientboundSetTitleTextPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/title/ClientboundSetTitleTextPacket.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 @With
 @AllArgsConstructor
 public class ClientboundSetTitleTextPacket implements MinecraftPacket {
-    private @NotNull final Component text;
+    private final @NotNull Component text;
 
     public ClientboundSetTitleTextPacket(ByteBuf in, MinecraftCodecHelper helper) throws IOException {
         this.text = helper.readComponent(in);
@@ -23,6 +23,6 @@ public class ClientboundSetTitleTextPacket implements MinecraftPacket {
 
     @Override
     public void serialize(ByteBuf out, MinecraftCodecHelper helper) throws IOException {
-        helper.writeComponent(out, getText());
+        helper.writeComponent(out, this.text);
     }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/title/ClientboundSetTitleTextPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/title/ClientboundSetTitleTextPacket.java
@@ -7,7 +7,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.With;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.NotNull;
+import lombok.NonNull;
 
 import java.io.IOException;
 
@@ -15,7 +15,7 @@ import java.io.IOException;
 @With
 @AllArgsConstructor
 public class ClientboundSetTitleTextPacket implements MinecraftPacket {
-    private final @NotNull Component text;
+    private final @NonNull Component text;
 
     public ClientboundSetTitleTextPacket(ByteBuf in, MinecraftCodecHelper helper) throws IOException {
         this.text = helper.readComponent(in);

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/title/ClientboundSetTitleTextPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/title/ClientboundSetTitleTextPacket.java
@@ -24,6 +24,6 @@ public class ClientboundSetTitleTextPacket implements MinecraftPacket {
 
     @Override
     public void serialize(ByteBuf out, MinecraftCodecHelper helper) throws IOException {
-        helper.writeString(out, DefaultComponentSerializer.get().serializeOr(this.text, "null"));
+        helper.writeComponent(out, getText() != null ? getText() : Component.text("null"));
     }
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/title/ClientboundSetTitleTextPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/title/ClientboundSetTitleTextPacket.java
@@ -2,13 +2,12 @@ package com.github.steveice10.mc.protocol.packet.ingame.clientbound.title;
 
 import com.github.steveice10.mc.protocol.codec.MinecraftCodecHelper;
 import com.github.steveice10.mc.protocol.codec.MinecraftPacket;
-import com.github.steveice10.mc.protocol.data.DefaultComponentSerializer;
 import io.netty.buffer.ByteBuf;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.With;
 import net.kyori.adventure.text.Component;
-import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 
@@ -16,7 +15,7 @@ import java.io.IOException;
 @With
 @AllArgsConstructor
 public class ClientboundSetTitleTextPacket implements MinecraftPacket {
-    private final @Nullable Component text;
+    private @NotNull final Component text;
 
     public ClientboundSetTitleTextPacket(ByteBuf in, MinecraftCodecHelper helper) throws IOException {
         this.text = helper.readComponent(in);
@@ -24,6 +23,6 @@ public class ClientboundSetTitleTextPacket implements MinecraftPacket {
 
     @Override
     public void serialize(ByteBuf out, MinecraftCodecHelper helper) throws IOException {
-        helper.writeComponent(out, getText() != null ? getText() : Component.text("null"));
+        helper.writeComponent(out, getText());
     }
 }


### PR DESCRIPTION
The title component should being encoded as an NBT tag instead of a string.

This should fix the 1.20.4 vanilla client disconnecting when connecting with an exception.
The title component is now NotNull.