### PR TITLE
Make readBlockEntityType() nullable 

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/codec/MinecraftCodecHelper.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/codec/MinecraftCodecHelper.java
@@ -620,15 +620,9 @@ public class MinecraftCodecHelper extends BasePacketCodecHelper {
         }
     }
 
-    @NotNull
+    @Nullable
     public BlockEntityType readBlockEntityType(ByteBuf buf) {
-        int id = this.readVarInt(buf);
-        BlockEntityType type = BlockEntityType.from(id);
-
-        if (type == null) {
-            throw new IllegalArgumentException("Unknown BlockEntityType: " + id);
-        }
-        return type;
+        return BlockEntityType.from(this.readVarInt(buf));
     }
 
     public void writeBlockEntityType(ByteBuf buf, BlockEntityType type) {


### PR DESCRIPTION
The vanilla client does so too - it allows reading a null value, but wont write one.

![image](https://github.com/GeyserMC/MCProtocolLib/assets/105284508/b51e0fbb-ad73-402e-b1da-053d5bc6df17)
