### PR TITLE
Throw when trying to write an unknown block entity type

### DIFF
--- a/src/main/java/com/github/steveice10/mc/protocol/codec/MinecraftCodecHelper.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/codec/MinecraftCodecHelper.java
@@ -626,6 +626,9 @@ public class MinecraftCodecHelper extends BasePacketCodecHelper {
     }
 
     public void writeBlockEntityType(ByteBuf buf, BlockEntityType type) {
+        if (type == null) {
+            throw new IllegalArgumentException("Cannot write an unknown BlockEntityType!");
+        }
         this.writeEnum(buf, type);
     }
 

--- a/src/main/java/com/github/steveice10/mc/protocol/data/game/level/block/BlockEntityInfo.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/data/game/level/block/BlockEntityInfo.java
@@ -11,6 +11,6 @@ public class BlockEntityInfo {
     private final int x;
     private final int y;
     private final int z;
-    private final BlockEntityType type;
+    private final @Nullable BlockEntityType type;
     private final @Nullable CompoundTag nbt;
 }

--- a/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/level/ClientboundBlockEntityDataPacket.java
+++ b/src/main/java/com/github/steveice10/mc/protocol/packet/ingame/clientbound/level/ClientboundBlockEntityDataPacket.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 @AllArgsConstructor
 public class ClientboundBlockEntityDataPacket implements MinecraftPacket {
     private final @NonNull Vector3i position;
-    private final @NonNull BlockEntityType type;
+    private final @Nullable BlockEntityType type;
     private final @Nullable CompoundTag nbt;
 
     public ClientboundBlockEntityDataPacket(ByteBuf in, MinecraftCodecHelper helper) throws IOException {


### PR DESCRIPTION
This marks the type fields in BlockEntityInfo and ClientboundBlockEntityDataPacket as being nullable, and throws when trying to write a null type. 