### PR TITLE
Disable code signing for Jitpack

### DIFF
--- a/buildSrc/src/main/kotlin/mcprotocollib.base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mcprotocollib.base-conventions.gradle.kts
@@ -18,10 +18,11 @@ indra {
     }
 }
 
-tasks.withType<Sign>().configureEach {
-    onlyIf { false }
+if (System.getenv("JITPACK") == "true") {
+    tasks.withType<Sign>().configureEach {
+        onlyIf { false }
+    }
 }
-
 lombok {
     version = libs.versions.lombok.version.get()
 }

--- a/buildSrc/src/main/kotlin/mcprotocollib.base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/mcprotocollib.base-conventions.gradle.kts
@@ -18,6 +18,10 @@ indra {
     }
 }
 
+tasks.withType<Sign>().configureEach {
+    onlyIf { false }
+}
+
 lombok {
     version = libs.versions.lombok.version.get()
 }


### PR DESCRIPTION
I'm doing the same thing in SkinsRestorer: https://github.com/SkinsRestorer/SkinsRestorer/blob/b7baa862d853764f7cfa2b5096af5cc921fcec85/buildSrc/src/main/kotlin/sr.base-logic.gradle.kts#L87-L89