### PR TITLE
Feature: server transfer feature flag

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
@@ -127,10 +127,12 @@ public class ClientListener extends SessionAdapter {
             } else if (packet instanceof ClientboundStartConfigurationPacket) {
                 session.send(new ServerboundConfigurationAcknowledgedPacket());
             } else if (packet instanceof ClientboundTransferPacket transferPacket) {
-                TcpClientSession newSession = new TcpClientSession(transferPacket.getHost(), transferPacket.getPort(), session.getPacketProtocol());
-                newSession.setFlags(session.getFlags());
-                session.disconnect("Transferring");
-                newSession.connect(true, true);
+                if (session.getFlag(MinecraftConstants.FOLLOW_TRANFERS, true)) {
+                    TcpClientSession newSession = new TcpClientSession(transferPacket.getHost(), transferPacket.getPort(), session.getPacketProtocol());
+                    newSession.setFlags(session.getFlags());
+                    session.disconnect("Transferring");
+                    newSession.connect(true, true);
+                }
             }
         } else if (protocol.getState() == ProtocolState.CONFIGURATION) {
             if (packet instanceof ClientboundFinishConfigurationPacket) {
@@ -140,10 +142,12 @@ public class ClientListener extends SessionAdapter {
                     session.send(new ServerboundSelectKnownPacks(Collections.emptyList()));
                 }
             } else if (packet instanceof ClientboundTransferPacket transferPacket) {
-                TcpClientSession newSession = new TcpClientSession(transferPacket.getHost(), transferPacket.getPort(), session.getPacketProtocol());
-                newSession.setFlags(session.getFlags());
-                session.disconnect("Transferring");
-                newSession.connect(true, true);
+                if (session.getFlag(MinecraftConstants.FOLLOW_TRANFERS, true)) {
+                    TcpClientSession newSession = new TcpClientSession(transferPacket.getHost(), transferPacket.getPort(), session.getPacketProtocol());
+                    newSession.setFlags(session.getFlags());
+                    session.disconnect("Transferring");
+                    newSession.connect(true, true);
+                }
             }
         }
     }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftConstants.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftConstants.java
@@ -55,6 +55,11 @@ public final class MinecraftConstants {
      */
     public static final Flag<Boolean> SEND_BLANK_KNOWN_PACKS_RESPONSE = new Flag<>("send-blank-known-packs-response", Boolean.class);
 
+    /**
+     * Session flag for determining whether to create a new TcpClientSession when the Java server sends a ClientboundTransferPacket.
+     */
+    public static final Flag<Boolean> FOLLOW_TRANFERS = new Flag<>("follow-transfers", Boolean.class);
+
     // Server Key Constants
 
     /**


### PR DESCRIPTION
Allow users of the default client listener to decide whether to automatically follow transfer packets. 
For example: Geyser would either disconnect players, or transfer them away with the Bedrock transfer packets, in which case a new TcpClientSession would not be needed.