### PR TITLE
Static sizer and timeout handlers in the pipeline

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
@@ -6,6 +6,7 @@ import java.net.InetSocketAddress;
  * Built-in PacketLib session flags.
  */
 public class BuiltinFlags {
+
     /**
      * Enables HAProxy protocol support.
      * When this value is not null it means the ip and port the client claims the connection is from.

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
@@ -6,8 +6,6 @@ import java.net.InetSocketAddress;
  * Built-in PacketLib session flags.
  */
 public class BuiltinFlags {
-    public static final Flag<Boolean> ENABLE_CLIENT_PROXY_PROTOCOL = new Flag<>("enable-client-proxy-protocol", Boolean.class);
-
     public static final Flag<InetSocketAddress> CLIENT_PROXIED_ADDRESS = new Flag<>("client-proxied-address", InetSocketAddress.class);
 
     /**
@@ -19,6 +17,10 @@ public class BuiltinFlags {
      * When set to true, the client or server will attempt to use TCP Fast Open if supported.
      */
     public static final Flag<Boolean> TCP_FAST_OPEN = new Flag<>("tcp-fast-open", Boolean.class);
+
+    public static final Flag<Integer> CLIENT_CONNECT_TIMEOUT = new Flag<>("client-connect-timeout", Integer.class);
+    public static final Flag<Integer> READ_TIMEOUT = new Flag<>("read-timeout", Integer.class);
+    public static final Flag<Integer> WRITE_TIMEOUT = new Flag<>("write-timeout", Integer.class);
 
     private BuiltinFlags() {
     }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
@@ -9,7 +9,7 @@ public class BuiltinFlags {
 
     /**
      * Enables HAProxy protocol support.
-     * When this value is not null it means the ip and port the client claims the connection is from.
+     * When this value is not null it represents the ip and port the client claims the connection is from.
      */
     public static final Flag<InetSocketAddress> CLIENT_PROXIED_ADDRESS = new Flag<>("client-proxied-address", InetSocketAddress.class);
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
@@ -28,11 +28,13 @@ public class BuiltinFlags {
      * Only used by the client.
      */
     public static final Flag<Integer> CLIENT_CONNECT_TIMEOUT = new Flag<>("client-connect-timeout", Integer.class);
+    
     /**
      * Read timeout in seconds.
      * Used by both server and client.
      */
     public static final Flag<Integer> READ_TIMEOUT = new Flag<>("read-timeout", Integer.class);
+    
     /**
      * Write timeout in seconds.
      * Used by both server and client.

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
@@ -31,7 +31,7 @@ public class BuiltinFlags {
     
     /**
      * Read timeout in seconds.
-     * Used by both server and client.
+     * Used by both the server and client.
      */
     public static final Flag<Integer> READ_TIMEOUT = new Flag<>("read-timeout", Integer.class);
     

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
@@ -6,6 +6,10 @@ import java.net.InetSocketAddress;
  * Built-in PacketLib session flags.
  */
 public class BuiltinFlags {
+    /**
+     * Enables HAProxy protocol support.
+     * When this value is not null it means the ip and port the client claims the connection is from.
+     */
     public static final Flag<InetSocketAddress> CLIENT_PROXIED_ADDRESS = new Flag<>("client-proxied-address", InetSocketAddress.class);
 
     /**
@@ -18,8 +22,20 @@ public class BuiltinFlags {
      */
     public static final Flag<Boolean> TCP_FAST_OPEN = new Flag<>("tcp-fast-open", Boolean.class);
 
+    /**
+     * Connection timeout in seconds.
+     * Only used by the client.
+     */
     public static final Flag<Integer> CLIENT_CONNECT_TIMEOUT = new Flag<>("client-connect-timeout", Integer.class);
+    /**
+     * Read timeout in seconds.
+     * Used by both server and client.
+     */
     public static final Flag<Integer> READ_TIMEOUT = new Flag<>("read-timeout", Integer.class);
+    /**
+     * Write timeout in seconds.
+     * Used by both server and client.
+     */
     public static final Flag<Integer> WRITE_TIMEOUT = new Flag<>("write-timeout", Integer.class);
 
     private BuiltinFlags() {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/BuiltinFlags.java
@@ -37,7 +37,7 @@ public class BuiltinFlags {
     
     /**
      * Write timeout in seconds.
-     * Used by both server and client.
+     * Used by both the server and client.
      */
     public static final Flag<Integer> WRITE_TIMEOUT = new Flag<>("write-timeout", Integer.class);
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
@@ -36,7 +36,7 @@ public interface Session {
      * @param wait Whether to wait for the connection to be established before returning.
      * @param transferring Whether the session is a client being transferred.
      */
-    public void connect(boolean wait, boolean transferring);
+    void connect(boolean wait, boolean transferring);
 
     /**
      * Gets the host the session is connected to.
@@ -137,7 +137,7 @@ public interface Session {
      *
      * @param flags Collection of flags
      */
-    public void setFlags(Map<String, Object> flags);
+    void setFlags(Map<String, Object> flags);
 
     /**
      * Gets the listeners listening on this session.
@@ -202,48 +202,6 @@ public interface Session {
      * @param encryption the encryption to encrypt with
      */
     void enableEncryption(PacketEncryption encryption);
-
-    /**
-     * Gets the connect timeout for this session in seconds.
-     *
-     * @return The session's connect timeout.
-     */
-    int getConnectTimeout();
-
-    /**
-     * Sets the connect timeout for this session in seconds.
-     *
-     * @param timeout Connect timeout to set.
-     */
-    void setConnectTimeout(int timeout);
-
-    /**
-     * Gets the read timeout for this session in seconds.
-     *
-     * @return The session's read timeout.
-     */
-    int getReadTimeout();
-
-    /**
-     * Sets the read timeout for this session in seconds.
-     *
-     * @param timeout Read timeout to set.
-     */
-    void setReadTimeout(int timeout);
-
-    /**
-     * Gets the write timeout for this session in seconds.
-     *
-     * @return The session's write timeout.
-     */
-    int getWriteTimeout();
-
-    /**
-     * Sets the write timeout for this session in seconds.
-     *
-     * @param timeout Write timeout to set.
-     */
-    void setWriteTimeout(int timeout);
 
     /**
      * Returns true if the session is connected.

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
@@ -124,15 +124,17 @@ public class TcpClientSession extends TcpSession {
             bootstrap.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
         }
 
-        ChannelFuture future = bootstrap.connect().addListener((futureListener) -> {
-            if (!futureListener.isSuccess()) {
-                exceptionCaught(null, futureListener.cause());
-            }
-        });
+        ChannelFuture future = bootstrap.connect();
 
         if (wait) {
             future.syncUninterruptibly();
         }
+
+        future.addListener((futureListener) -> {
+            if (!futureListener.isSuccess()) {
+                exceptionCaught(null, futureListener.cause());
+            }
+        });
     }
 
     @Override

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
@@ -5,8 +5,6 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -25,11 +23,13 @@ import io.netty.handler.codec.haproxy.HAProxyProxiedProtocol;
 import io.netty.handler.proxy.HttpProxyHandler;
 import io.netty.handler.proxy.Socks4ProxyHandler;
 import io.netty.handler.proxy.Socks5ProxyHandler;
+import io.netty.handler.timeout.ReadTimeoutHandler;
+import io.netty.handler.timeout.WriteTimeoutHandler;
 import io.netty.resolver.dns.DnsNameResolver;
 import io.netty.resolver.dns.DnsNameResolverBuilder;
 import io.netty.util.concurrent.DefaultThreadFactory;
-import org.geysermc.mcprotocollib.network.ProxyInfo;
 import org.geysermc.mcprotocollib.network.BuiltinFlags;
+import org.geysermc.mcprotocollib.network.ProxyInfo;
 import org.geysermc.mcprotocollib.network.codec.PacketCodecHelper;
 import org.geysermc.mcprotocollib.network.helper.TransportHelper;
 import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
@@ -90,56 +90,48 @@ public class TcpClientSession extends TcpSession {
             createTcpEventLoopGroup();
         }
 
-        try {
-            final Bootstrap bootstrap = new Bootstrap()
-                    .channelFactory(TRANSPORT_TYPE.socketChannelFactory())
-                    .option(ChannelOption.TCP_NODELAY, true)
-                    .option(ChannelOption.IP_TOS, 0x18)
-                    .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getConnectTimeout() * 1000)
-                    .group(EVENT_LOOP_GROUP)
-                    .remoteAddress(resolveAddress())
-                    .localAddress(bindAddress, bindPort)
-                    .handler(new ChannelInitializer<>() {
-                        @Override
-                        public void initChannel(Channel channel) {
-                            PacketProtocol protocol = getPacketProtocol();
-                            protocol.newClientSession(TcpClientSession.this, transferring);
+        final Bootstrap bootstrap = new Bootstrap()
+            .channelFactory(TRANSPORT_TYPE.socketChannelFactory())
+            .option(ChannelOption.TCP_NODELAY, true)
+            .option(ChannelOption.IP_TOS, 0x18)
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, getFlag(BuiltinFlags.CLIENT_CONNECT_TIMEOUT, 30) * 1000)
+            .group(EVENT_LOOP_GROUP)
+            .remoteAddress(resolveAddress())
+            .localAddress(bindAddress, bindPort)
+            .handler(new ChannelInitializer<>() {
+                @Override
+                public void initChannel(Channel channel) {
+                    PacketProtocol protocol = getPacketProtocol();
+                    protocol.newClientSession(TcpClientSession.this, transferring);
 
-                            ChannelPipeline pipeline = channel.pipeline();
+                    ChannelPipeline pipeline = channel.pipeline();
 
-                            refreshReadTimeoutHandler(channel);
-                            refreshWriteTimeoutHandler(channel);
+                    addProxy(pipeline);
 
-                            addProxy(pipeline);
+                    addHAProxySupport(channel);
 
-                            int size = protocol.getPacketHeader().getLengthSize();
-                            if (size > 0) {
-                                pipeline.addLast("sizer", new TcpPacketSizer(TcpClientSession.this, size));
-                            }
+                    pipeline.addLast("read-timeout", new ReadTimeoutHandler(getFlag(BuiltinFlags.READ_TIMEOUT, 30)));
+                    pipeline.addLast("write-timeout", new WriteTimeoutHandler(getFlag(BuiltinFlags.WRITE_TIMEOUT, 0)));
 
-                            pipeline.addLast("codec", new TcpPacketCodec(TcpClientSession.this, true));
-                            pipeline.addLast("manager", TcpClientSession.this);
+                    pipeline.addLast("sizer", new TcpPacketSizer(protocol.getPacketHeader(), getCodecHelper()));
 
-                            addHAProxySupport(pipeline);
-                        }
-                    });
-
-            if (getFlag(BuiltinFlags.TCP_FAST_OPEN, false) && TRANSPORT_TYPE.supportsTcpFastOpenClient()) {
-                bootstrap.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
-            }
-
-            ChannelFuture future = bootstrap.connect();
-            if (wait) {
-                future.sync();
-            }
-
-            future.addListener((futureListener) -> {
-                if (!futureListener.isSuccess()) {
-                    exceptionCaught(null, futureListener.cause());
+                    pipeline.addLast("codec", new TcpPacketCodec(TcpClientSession.this, true));
+                    pipeline.addLast("manager", TcpClientSession.this);
                 }
             });
-        } catch (Throwable t) {
-            exceptionCaught(null, t);
+
+        if (getFlag(BuiltinFlags.TCP_FAST_OPEN, false) && TRANSPORT_TYPE.supportsTcpFastOpenClient()) {
+            bootstrap.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
+        }
+
+        ChannelFuture future = bootstrap.connect().addListener((futureListener) -> {
+            if (!futureListener.isSuccess()) {
+                exceptionCaught(null, futureListener.cause());
+            }
+        });
+
+        if (wait) {
+            future.syncUninterruptibly();
         }
     }
 
@@ -155,8 +147,8 @@ public class TcpClientSession extends TcpSession {
         if (getFlag(BuiltinFlags.ATTEMPT_SRV_RESOLVE, true) && (!this.host.matches(IP_REGEX) && !this.host.equalsIgnoreCase("localhost"))) {
             AddressedEnvelope<DnsResponse, InetSocketAddress> envelope = null;
             try (DnsNameResolver resolver = new DnsNameResolverBuilder(EVENT_LOOP_GROUP.next())
-                    .channelFactory(TRANSPORT_TYPE.datagramChannelFactory())
-                    .build()) {
+                .channelFactory(TRANSPORT_TYPE.datagramChannelFactory())
+                .build()) {
                 envelope = resolver.query(new DefaultDnsQuestion(name, DnsRecordType.SRV)).get();
 
                 DnsResponse response = envelope.content();
@@ -206,54 +198,52 @@ public class TcpClientSession extends TcpSession {
     }
 
     private void addProxy(ChannelPipeline pipeline) {
-        if (proxy != null) {
-            switch (proxy.type()) {
-                case HTTP -> {
-                    if (proxy.username() != null && proxy.password() != null) {
-                        pipeline.addFirst("proxy", new HttpProxyHandler(proxy.address(), proxy.username(), proxy.password()));
-                    } else {
-                        pipeline.addFirst("proxy", new HttpProxyHandler(proxy.address()));
-                    }
+        if (proxy == null) {
+            return;
+        }
+
+        switch (proxy.type()) {
+            case HTTP -> {
+                if (proxy.username() != null && proxy.password() != null) {
+                    pipeline.addLast("proxy", new HttpProxyHandler(proxy.address(), proxy.username(), proxy.password()));
+                } else {
+                    pipeline.addLast("proxy", new HttpProxyHandler(proxy.address()));
                 }
-                case SOCKS4 -> {
-                    if (proxy.username() != null) {
-                        pipeline.addFirst("proxy", new Socks4ProxyHandler(proxy.address(), proxy.username()));
-                    } else {
-                        pipeline.addFirst("proxy", new Socks4ProxyHandler(proxy.address()));
-                    }
-                }
-                case SOCKS5 -> {
-                    if (proxy.username() != null && proxy.password() != null) {
-                        pipeline.addFirst("proxy", new Socks5ProxyHandler(proxy.address(), proxy.username(), proxy.password()));
-                    } else {
-                        pipeline.addFirst("proxy", new Socks5ProxyHandler(proxy.address()));
-                    }
-                }
-                default -> throw new UnsupportedOperationException("Unsupported proxy type: " + proxy.type());
             }
+            case SOCKS4 -> {
+                if (proxy.username() != null) {
+                    pipeline.addLast("proxy", new Socks4ProxyHandler(proxy.address(), proxy.username()));
+                } else {
+                    pipeline.addLast("proxy", new Socks4ProxyHandler(proxy.address()));
+                }
+            }
+            case SOCKS5 -> {
+                if (proxy.username() != null && proxy.password() != null) {
+                    pipeline.addLast("proxy", new Socks5ProxyHandler(proxy.address(), proxy.username(), proxy.password()));
+                } else {
+                    pipeline.addLast("proxy", new Socks5ProxyHandler(proxy.address()));
+                }
+            }
+            default -> throw new UnsupportedOperationException("Unsupported proxy type: " + proxy.type());
         }
     }
 
-    private void addHAProxySupport(ChannelPipeline pipeline) {
+    private void addHAProxySupport(Channel channel) {
         InetSocketAddress clientAddress = getFlag(BuiltinFlags.CLIENT_PROXIED_ADDRESS);
-        if (getFlag(BuiltinFlags.ENABLE_CLIENT_PROXY_PROTOCOL, false) && clientAddress != null) {
-            pipeline.addFirst("proxy-protocol-packet-sender", new ChannelInboundHandlerAdapter() {
-                @Override
-                public void channelActive(ChannelHandlerContext ctx) throws Exception {
-                    HAProxyProxiedProtocol proxiedProtocol = clientAddress.getAddress() instanceof Inet4Address ? HAProxyProxiedProtocol.TCP4 : HAProxyProxiedProtocol.TCP6;
-                    InetSocketAddress remoteAddress = (InetSocketAddress) ctx.channel().remoteAddress();
-                    ctx.channel().writeAndFlush(new HAProxyMessage(
-                            HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, proxiedProtocol,
-                            clientAddress.getAddress().getHostAddress(), remoteAddress.getAddress().getHostAddress(),
-                            clientAddress.getPort(), remoteAddress.getPort()
-                    ));
-                    ctx.pipeline().remove(this);
-                    ctx.pipeline().remove("proxy-protocol-encoder");
-                    super.channelActive(ctx);
-                }
-            });
-            pipeline.addFirst("proxy-protocol-encoder", HAProxyMessageEncoder.INSTANCE);
+        if (clientAddress == null) {
+            return;
         }
+
+        channel.pipeline().addLast("proxy-protocol-encoder", HAProxyMessageEncoder.INSTANCE);
+        HAProxyProxiedProtocol proxiedProtocol = clientAddress.getAddress() instanceof Inet4Address ? HAProxyProxiedProtocol.TCP4 : HAProxyProxiedProtocol.TCP6;
+        InetSocketAddress remoteAddress = (InetSocketAddress) channel.remoteAddress();
+        channel.writeAndFlush(new HAProxyMessage(
+            HAProxyProtocolVersion.V2, HAProxyCommand.PROXY, proxiedProtocol,
+            clientAddress.getAddress().getHostAddress(), remoteAddress.getAddress().getHostAddress(),
+            clientAddress.getPort(), remoteAddress.getPort()
+        )).addListener(future -> {
+            channel.pipeline().remove("proxy-protocol-encoder");
+        });
     }
 
     @Override
@@ -269,7 +259,7 @@ public class TcpClientSession extends TcpSession {
         EVENT_LOOP_GROUP = TRANSPORT_TYPE.eventLoopGroupFactory().apply(newThreadFactory());
 
         Runtime.getRuntime().addShutdownHook(new Thread(
-                () -> EVENT_LOOP_GROUP.shutdownGracefully(SHUTDOWN_QUIET_PERIOD_MS, SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)));
+            () -> EVENT_LOOP_GROUP.shutdownGracefully(SHUTDOWN_QUIET_PERIOD_MS, SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)));
     }
 
     protected static ThreadFactory newThreadFactory() {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
@@ -124,17 +124,15 @@ public class TcpClientSession extends TcpSession {
             bootstrap.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
         }
 
-        ChannelFuture future = bootstrap.connect();
-
-        if (wait) {
-            future.syncUninterruptibly();
-        }
-
-        future.addListener((futureListener) -> {
+        ChannelFuture future = bootstrap.connect().addListener((futureListener) -> {
             if (!futureListener.isSuccess()) {
                 exceptionCaught(null, futureListener.cause());
             }
         });
+
+        if (wait) {
+            future.syncUninterruptibly();
+        }
     }
 
     @Override

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
@@ -4,7 +4,6 @@ import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.AddressedEnvelope;
 import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
@@ -40,6 +39,7 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
@@ -124,14 +124,17 @@ public class TcpClientSession extends TcpSession {
             bootstrap.option(ChannelOption.TCP_FASTOPEN_CONNECT, true);
         }
 
-        ChannelFuture future = bootstrap.connect().addListener((futureListener) -> {
+        CompletableFuture<Void> handleFuture = new CompletableFuture<>();
+        bootstrap.connect().addListener((futureListener) -> {
             if (!futureListener.isSuccess()) {
                 exceptionCaught(null, futureListener.cause());
             }
+
+            handleFuture.complete(null);
         });
 
         if (wait) {
-            future.syncUninterruptibly();
+            handleFuture.join();
         }
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
@@ -108,7 +108,7 @@ public class TcpClientSession extends TcpSession {
 
                     addProxy(pipeline);
 
-                    addHAProxySupport(channel);
+                    initializeHAProxySupport(channel);
 
                     pipeline.addLast("read-timeout", new ReadTimeoutHandler(getFlag(BuiltinFlags.READ_TIMEOUT, 30)));
                     pipeline.addLast("write-timeout", new WriteTimeoutHandler(getFlag(BuiltinFlags.WRITE_TIMEOUT, 0)));
@@ -231,7 +231,7 @@ public class TcpClientSession extends TcpSession {
         }
     }
 
-    private void addHAProxySupport(Channel channel) {
+    private void initializeHAProxySupport(Channel channel) {
         InetSocketAddress clientAddress = getFlag(BuiltinFlags.CLIENT_PROXIED_ADDRESS);
         if (clientAddress == null) {
             return;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
@@ -121,9 +121,9 @@ public class TcpServer extends AbstractServer {
 
         if (this.group != null) {
             CompletableFuture<Void> handleFuture = new CompletableFuture<>();
-            this.group.shutdownGracefully().addListener(future1 -> {
-                if (!future1.isSuccess()) {
-                    log.debug("Failed to close connection listener.", future1.cause());
+            this.group.shutdownGracefully().addListener(future -> {
+                if (!future.isSuccess()) {
+                    log.debug("Failed to close connection listener.", future.cause());
                 }
 
                 handleFuture.complete(null);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
@@ -76,14 +76,14 @@ public class TcpServer extends AbstractServer {
         }
 
         CompletableFuture<Void> handleFuture = new CompletableFuture<>();
-        bootstrap.bind().addListener((ChannelFutureListener) future1 -> {
-            if (future1.isSuccess()) {
-                channel = future1.channel();
+        bootstrap.bind().addListener((ChannelFutureListener) future -> {
+            if (future.isSuccess()) {
+                channel = future.channel();
                 if (callback != null) {
                     callback.run();
                 }
             } else {
-                log.error("Failed to bind connection listener.", future1.cause());
+                log.error("Failed to bind connection listener.", future.cause());
             }
 
             handleFuture.complete(null);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
@@ -99,8 +99,8 @@ public class TcpServer extends AbstractServer {
         if (this.channel != null) {
             if (this.channel.isOpen()) {
                 CompletableFuture<Void> handleFuture = new CompletableFuture<>();
-                this.channel.close().addListener((ChannelFutureListener) future1 -> {
-                    if (future1.isSuccess()) {
+                this.channel.close().addListener((ChannelFutureListener) future -> {
+                    if (future.isSuccess()) {
                         if (callback != null) {
                             callback.run();
                         }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
@@ -105,7 +105,7 @@ public class TcpServer extends AbstractServer {
                             callback.run();
                         }
                     } else {
-                        log.error("Failed to close connection listener.", future1.cause());
+                        log.error("Failed to close connection listener.", future.cause());
                     }
 
                     handleFuture.complete(null);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
@@ -9,9 +9,7 @@ import io.netty.channel.EventLoop;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.timeout.ReadTimeoutException;
-import io.netty.handler.timeout.ReadTimeoutHandler;
 import io.netty.handler.timeout.WriteTimeoutException;
-import io.netty.handler.timeout.WriteTimeoutHandler;
 import io.netty.util.concurrent.DefaultThreadFactory;
 import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -51,9 +49,6 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
     private final EventLoop eventLoop = createEventLoop();
 
     private int compressionThreshold = -1;
-    private int connectTimeout = 30;
-    private int readTimeout = 30;
-    private int writeTimeout = 0;
 
     private final Map<String, Object> flags = new HashMap<>();
     private final List<SessionListener> listeners = new CopyOnWriteArrayList<>();
@@ -221,38 +216,6 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
     }
 
     @Override
-    public int getConnectTimeout() {
-        return this.connectTimeout;
-    }
-
-    @Override
-    public void setConnectTimeout(int timeout) {
-        this.connectTimeout = timeout;
-    }
-
-    @Override
-    public int getReadTimeout() {
-        return this.readTimeout;
-    }
-
-    @Override
-    public void setReadTimeout(int timeout) {
-        this.readTimeout = timeout;
-        this.refreshReadTimeoutHandler();
-    }
-
-    @Override
-    public int getWriteTimeout() {
-        return this.writeTimeout;
-    }
-
-    @Override
-    public void setWriteTimeout(int timeout) {
-        this.writeTimeout = timeout;
-        this.refreshWriteTimeoutHandler();
-    }
-
-    @Override
     public boolean isConnected() {
         return this.channel != null && this.channel.isOpen() && !this.disconnected;
     }
@@ -328,46 +291,6 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
 
     public Channel getChannel() {
         return this.channel;
-    }
-
-    protected void refreshReadTimeoutHandler() {
-        this.refreshReadTimeoutHandler(this.channel);
-    }
-
-    protected void refreshReadTimeoutHandler(Channel channel) {
-        if (channel != null) {
-            if (this.readTimeout <= 0) {
-                if (channel.pipeline().get("readTimeout") != null) {
-                    channel.pipeline().remove("readTimeout");
-                }
-            } else {
-                if (channel.pipeline().get("readTimeout") == null) {
-                    channel.pipeline().addFirst("readTimeout", new ReadTimeoutHandler(this.readTimeout));
-                } else {
-                    channel.pipeline().replace("readTimeout", "readTimeout", new ReadTimeoutHandler(this.readTimeout));
-                }
-            }
-        }
-    }
-
-    protected void refreshWriteTimeoutHandler() {
-        this.refreshWriteTimeoutHandler(this.channel);
-    }
-
-    protected void refreshWriteTimeoutHandler(Channel channel) {
-        if (channel != null) {
-            if (this.writeTimeout <= 0) {
-                if (channel.pipeline().get("writeTimeout") != null) {
-                    channel.pipeline().remove("writeTimeout");
-                }
-            } else {
-                if (channel.pipeline().get("writeTimeout") == null) {
-                    channel.pipeline().addFirst("writeTimeout", new WriteTimeoutHandler(this.writeTimeout));
-                } else {
-                    channel.pipeline().replace("writeTimeout", "writeTimeout", new WriteTimeoutHandler(this.writeTimeout));
-                }
-            }
-        }
     }
 
     @Override


### PR DESCRIPTION
This simplifies all pipeline code and ensures some listeners like the sizer are always present. The code already assumed that the sizer is always there and thus causes issues. The sizer can be deactivated still now and has pretty much no performance losses from this. The profit from this PR is that there is less logic with modifying the pipeline and thus developers interacting with the channel can assume specific things about the order and placements of elements in the pipeline. This will be useful once ViaVersion is supported, and it is expected that certain elements always are in the pipeline and don't change. My plan is to also always have an encryption and compression handler in the pipeline that is controlled via AttributeKeys from netty, but for that first #828 needs to be merged. So this PR only completes the goal partially, but that's fine. PR is ready for review like it is right now.