### PR TITLE
Properly read/write food components

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/ItemCodecHelper.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/ItemCodecHelper.java
@@ -249,7 +249,7 @@ public class ItemCodecHelper extends MinecraftCodecHelper {
         buf.writeFloat(properties.getSaturationModifier());
         buf.writeBoolean(properties.isCanAlwaysEat());
         buf.writeFloat(properties.getEatSeconds());
-        this.writeOptionalItemStack(buf, properties.getUsingConvertsTo());
+        this.writeNullable(buf, properties.getUsingConvertsTo(), this::writeOptionalItemStack);
 
         this.writeList(buf, properties.getEffects(), (output, effect) -> {
             this.writeEffectInstance(output, effect.getEffect());

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/ItemCodecHelper.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/ItemCodecHelper.java
@@ -233,7 +233,7 @@ public class ItemCodecHelper extends MinecraftCodecHelper {
         float saturationModifier = buf.readFloat();
         boolean canAlwaysEat = buf.readBoolean();
         float eatSeconds = buf.readFloat();
-        ItemStack usingConvertsTo = this.readOptionalItemStack(buf);
+        ItemStack usingConvertsTo = this.readNullable(buf, this::readOptionalItemStack);
 
         List<FoodProperties.PossibleEffect> effects = this.readList(buf, (input) -> {
             MobEffectInstance effect = this.readEffectInstance(input);


### PR DESCRIPTION
This fixes reading/writing food item data components with a `using_converts_to` field. Over network, this field has a boolean preceding it which indicates if the field is present, which wasn't read/written, causing the component to be read/written incorrectly. This was fixed by using `readNullable` and `writeNullable` in the respective read and write methods.