### PR TITLE
Implement static compression and encryption pipeline

### DIFF
--- a/example/src/main/java/org/geysermc/mcprotocollib/network/example/ClientSessionListener.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/network/example/ClientSessionListener.java
@@ -39,7 +39,7 @@ public class ClientSessionListener extends SessionAdapter {
     public void connected(ConnectedEvent event) {
         log.info("CLIENT Connected");
 
-        event.getSession().enableEncryption(((TestProtocol) event.getSession().getPacketProtocol()).getEncryption());
+        event.getSession().setEncryption(((TestProtocol) event.getSession().getPacketProtocol()).getEncryption());
         event.getSession().send(new PingPacket("hello"));
     }
 

--- a/example/src/main/java/org/geysermc/mcprotocollib/network/example/ServerListener.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/network/example/ServerListener.java
@@ -38,7 +38,7 @@ public class ServerListener extends ServerAdapter {
     public void sessionAdded(SessionAddedEvent event) {
         log.info("SERVER Session Added: {}:{}", event.getSession().getHost(), event.getSession().getPort());
         ((TestProtocol) event.getSession().getPacketProtocol()).setSecretKey(this.key);
-        event.getSession().enableEncryption(((TestProtocol) event.getSession().getPacketProtocol()).getEncryption());
+        event.getSession().setEncryption(((TestProtocol) event.getSession().getPacketProtocol()).getEncryption());
     }
 
     @Override

--- a/example/src/main/java/org/geysermc/mcprotocollib/network/example/TestProtocol.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/network/example/TestProtocol.java
@@ -8,7 +8,7 @@ import org.geysermc.mcprotocollib.network.codec.PacketCodecHelper;
 import org.geysermc.mcprotocollib.network.codec.PacketDefinition;
 import org.geysermc.mcprotocollib.network.codec.PacketSerializer;
 import org.geysermc.mcprotocollib.network.crypt.AESEncryption;
-import org.geysermc.mcprotocollib.network.crypt.PacketEncryption;
+import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 import org.geysermc.mcprotocollib.network.packet.DefaultPacketHeader;
 import org.geysermc.mcprotocollib.network.packet.PacketHeader;
 import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
@@ -23,7 +23,7 @@ public class TestProtocol extends PacketProtocol {
     private static final Logger log = LoggerFactory.getLogger(TestProtocol.class);
     private final PacketHeader header = new DefaultPacketHeader();
     private final PacketRegistry registry = new PacketRegistry();
-    private AESEncryption encrypt;
+    private EncryptionConfig encrypt;
 
     @SuppressWarnings("unused")
     public TestProtocol() {
@@ -51,7 +51,7 @@ public class TestProtocol extends PacketProtocol {
         });
 
         try {
-            this.encrypt = new AESEncryption(key);
+            this.encrypt = new EncryptionConfig(new AESEncryption(key));
         } catch (GeneralSecurityException e) {
             log.error("Failed to create encryption", e);
         }
@@ -67,7 +67,7 @@ public class TestProtocol extends PacketProtocol {
         return this.header;
     }
 
-    public PacketEncryption getEncryption() {
+    public EncryptionConfig getEncryption() {
         return this.encrypt;
     }
 

--- a/example/src/main/java/org/geysermc/mcprotocollib/protocol/example/MinecraftProtocolTest.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/protocol/example/MinecraftProtocolTest.java
@@ -48,7 +48,8 @@ import java.util.BitSet;
 public class MinecraftProtocolTest {
     private static final Logger log = LoggerFactory.getLogger(MinecraftProtocolTest.class);
     private static final boolean SPAWN_SERVER = true;
-    private static final boolean VERIFY_USERS = false;
+    private static final boolean ENCRYPT_CONNECTION = true;
+    private static final boolean SHOULD_AUTHENTICATE = false;
     private static final String HOST = "127.0.0.1";
     private static final int PORT = 25565;
     private static final ProxyInfo PROXY = null;
@@ -63,7 +64,8 @@ public class MinecraftProtocolTest {
 
             Server server = new TcpServer(HOST, PORT, MinecraftProtocol::new);
             server.setGlobalFlag(MinecraftConstants.SESSION_SERVICE_KEY, sessionService);
-            server.setGlobalFlag(MinecraftConstants.VERIFY_USERS_KEY, VERIFY_USERS);
+            server.setGlobalFlag(MinecraftConstants.ENCRYPT_CONNECTION, ENCRYPT_CONNECTION);
+            server.setGlobalFlag(MinecraftConstants.SHOULD_AUTHENTICATE, SHOULD_AUTHENTICATE);
             server.setGlobalFlag(MinecraftConstants.SERVER_INFO_BUILDER_KEY, session ->
                     new ServerStatusInfo(
                             Component.text("Hello world!"),
@@ -100,7 +102,7 @@ public class MinecraftProtocolTest {
                     ))
             );
 
-            server.setGlobalFlag(MinecraftConstants.SERVER_COMPRESSION_THRESHOLD, 100);
+            server.setGlobalFlag(MinecraftConstants.SERVER_COMPRESSION_THRESHOLD, 256);
             server.addListener(new ServerAdapter() {
                 @Override
                 public void serverClosed(ServerClosedEvent event) {
@@ -177,7 +179,7 @@ public class MinecraftProtocolTest {
 
     private static void login() {
         MinecraftProtocol protocol;
-        if (VERIFY_USERS) {
+        if (SHOULD_AUTHENTICATE) {
             StepFullJavaSession.FullJavaSession fullJavaSession;
             try {
                 fullJavaSession = MinecraftAuth.JAVA_CREDENTIALS_LOGIN.getFromInput(

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/NetworkConstants.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/NetworkConstants.java
@@ -5,6 +5,6 @@ import org.geysermc.mcprotocollib.network.compression.CompressionConfig;
 import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 
 public class NetworkConstants {
-    public static final AttributeKey<CompressionConfig> COMPRESSION_ATTRIBUTE_KEY = AttributeKey.valueOf("compression_threshold");
+    public static final AttributeKey<CompressionConfig> COMPRESSION_ATTRIBUTE_KEY = AttributeKey.valueOf("compression");
     public static final AttributeKey<EncryptionConfig> ENCRYPTION_ATTRIBUTE_KEY = AttributeKey.valueOf("encryption");
 }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/NetworkConstants.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/NetworkConstants.java
@@ -1,0 +1,10 @@
+package org.geysermc.mcprotocollib.network;
+
+import io.netty.util.AttributeKey;
+import org.geysermc.mcprotocollib.network.compression.CompressionConfig;
+import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
+
+public class NetworkConstants {
+    public static final AttributeKey<CompressionConfig> COMPRESSION_ATTRIBUTE_KEY = AttributeKey.valueOf("compression_threshold");
+    public static final AttributeKey<EncryptionConfig> ENCRYPTION_ATTRIBUTE_KEY = AttributeKey.valueOf("encryption");
+}

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
@@ -189,7 +189,7 @@ public interface Session {
      * @param compressionConfig the compression to compress with,
      *                          or null to disable compression
      */
-    void setCompression(CompressionConfig compressionConfig);
+    void setCompression(@Nullable CompressionConfig compressionConfig);
 
     /**
      * Sets encryption for this session.
@@ -198,7 +198,7 @@ public interface Session {
      *                         or null to disable encryption
      *
      */
-    void setEncryption(EncryptionConfig encryptionConfig);
+    void setEncryption(@Nullable EncryptionConfig encryptionConfig);
 
     /**
      * Returns true if the session is connected.

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
@@ -4,7 +4,8 @@ import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.mcprotocollib.network.codec.PacketCodecHelper;
-import org.geysermc.mcprotocollib.network.crypt.PacketEncryption;
+import org.geysermc.mcprotocollib.network.compression.CompressionConfig;
+import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 import org.geysermc.mcprotocollib.network.event.session.SessionEvent;
 import org.geysermc.mcprotocollib.network.event.session.SessionListener;
 import org.geysermc.mcprotocollib.network.packet.Packet;
@@ -183,28 +184,23 @@ public interface Session {
     void callPacketSent(Packet packet);
 
     /**
-     * Gets the compression packet length threshold for this session (-1 = disabled).
+     * Sets compression for this session.
      *
-     * @return This session's compression threshold.
+     * @param compressionConfig the compression to compress with
+     *                          or null to disable compression
      */
-    int getCompressionThreshold();
+    void setCompression(CompressionConfig compressionConfig);
 
     /**
-     * Sets the compression packet length threshold for this session (-1 = disabled).
+     * Sets encryption for this session.
      *
-     * @param threshold The new compression threshold.
-     * @param validateDecompression whether to validate that the decompression fits within size checks.
-     */
-    void setCompressionThreshold(int threshold, boolean validateDecompression);
-
-    /**
-     * Enables encryption for this session.
+     * @param encryptionConfig the encryption to encrypt with
+     *                         or null to disable encryption
      *
-     * @param encryption the encryption to encrypt with
      */
-    void enableEncryption(PacketEncryption encryption);
+    void setEncryption(EncryptionConfig encryptionConfig);
 
-    /**
+                       /**
      * Returns true if the session is connected.
      *
      * @return True if the session is connected.

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
@@ -194,7 +194,7 @@ public interface Session {
     /**
      * Sets encryption for this session.
      *
-     * @param encryptionConfig the encryption to encrypt with
+     * @param encryptionConfig the encryption to encrypt with,
      *                         or null to disable encryption
      *
      */

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
@@ -200,7 +200,7 @@ public interface Session {
      */
     void setEncryption(EncryptionConfig encryptionConfig);
 
-                       /**
+    /**
      * Returns true if the session is connected.
      *
      * @return True if the session is connected.

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
@@ -184,7 +184,7 @@ public interface Session {
     void callPacketSent(Packet packet);
 
     /**
-     * Sets compression for this session.
+     * Sets the compression config for this session.
      *
      * @param compressionConfig the compression to compress with
      *                          or null to disable compression

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
@@ -186,7 +186,7 @@ public interface Session {
     /**
      * Sets the compression config for this session.
      *
-     * @param compressionConfig the compression to compress with
+     * @param compressionConfig the compression to compress with,
      *                          or null to disable compression
      */
     void setCompression(CompressionConfig compressionConfig);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/compression/CompressionConfig.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/compression/CompressionConfig.java
@@ -1,0 +1,4 @@
+package org.geysermc.mcprotocollib.network.compression;
+
+public record CompressionConfig(int threshold, PacketCompression compression, boolean validateDecompression) {
+}

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/crypt/EncryptionConfig.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/crypt/EncryptionConfig.java
@@ -1,0 +1,4 @@
+package org.geysermc.mcprotocollib.network.crypt;
+
+public record EncryptionConfig(PacketEncryption encryption) {
+}

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
@@ -113,7 +113,9 @@ public class TcpClientSession extends TcpSession {
                     pipeline.addLast("read-timeout", new ReadTimeoutHandler(getFlag(BuiltinFlags.READ_TIMEOUT, 30)));
                     pipeline.addLast("write-timeout", new WriteTimeoutHandler(getFlag(BuiltinFlags.WRITE_TIMEOUT, 0)));
 
+                    pipeline.addLast("encryption", new TcpPacketEncryptor());
                     pipeline.addLast("sizer", new TcpPacketSizer(protocol.getPacketHeader(), getCodecHelper()));
+                    pipeline.addLast("compression", new TcpPacketCompression(getCodecHelper()));
 
                     pipeline.addLast("codec", new TcpPacketCodec(TcpClientSession.this, true));
                     pipeline.addLast("manager", TcpClientSession.this);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpPacketCompression.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpPacketCompression.java
@@ -4,44 +4,49 @@ import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.MessageToMessageCodec;
-import org.geysermc.mcprotocollib.network.Session;
-import org.geysermc.mcprotocollib.network.compression.PacketCompression;
+import lombok.RequiredArgsConstructor;
+import org.geysermc.mcprotocollib.network.NetworkConstants;
+import org.geysermc.mcprotocollib.network.codec.PacketCodecHelper;
+import org.geysermc.mcprotocollib.network.compression.CompressionConfig;
 
 import java.util.List;
 
+@RequiredArgsConstructor
 public class TcpPacketCompression extends MessageToMessageCodec<ByteBuf, ByteBuf> {
     private static final int MAX_UNCOMPRESSED_SIZE = 8 * 1024 * 1024; // 8MiB
-
-    private final Session session;
-    private final PacketCompression compression;
-    private final boolean validateDecompression;
-
-    public TcpPacketCompression(Session session, PacketCompression compression, boolean validateDecompression) {
-        this.session = session;
-        this.compression = compression;
-        this.validateDecompression = validateDecompression;
-    }
+    private final PacketCodecHelper helper;
 
     @Override
     public void handlerRemoved(ChannelHandlerContext ctx) {
-        this.compression.close();
+        CompressionConfig config = ctx.channel().attr(NetworkConstants.COMPRESSION_ATTRIBUTE_KEY).get();
+        if (config == null) {
+            return;
+        }
+
+        config.compression().close();
     }
 
     @Override
     public void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) {
+        CompressionConfig config = ctx.channel().attr(NetworkConstants.COMPRESSION_ATTRIBUTE_KEY).get();
+        if (config == null) {
+            out.add(msg.retain());
+            return;
+        }
+
         int uncompressed = msg.readableBytes();
         if (uncompressed > MAX_UNCOMPRESSED_SIZE) {
             throw new IllegalArgumentException("Packet too big (is " + uncompressed + ", should be less than " + MAX_UNCOMPRESSED_SIZE + ")");
         }
 
         ByteBuf outBuf = ctx.alloc().directBuffer(uncompressed);
-        if (uncompressed < this.session.getCompressionThreshold()) {
+        if (uncompressed < config.threshold()) {
             // Under the threshold, there is nothing to do.
-            this.session.getCodecHelper().writeVarInt(outBuf, 0);
+            this.helper.writeVarInt(outBuf, 0);
             outBuf.writeBytes(msg);
         } else {
-            this.session.getCodecHelper().writeVarInt(outBuf, uncompressed);
-            compression.deflate(msg, outBuf);
+            this.helper.writeVarInt(outBuf, uncompressed);
+            config.compression().deflate(msg, outBuf);
         }
 
         out.add(outBuf);
@@ -49,15 +54,21 @@ public class TcpPacketCompression extends MessageToMessageCodec<ByteBuf, ByteBuf
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
-        int claimedUncompressedSize = this.session.getCodecHelper().readVarInt(in);
+        CompressionConfig config = ctx.channel().attr(NetworkConstants.COMPRESSION_ATTRIBUTE_KEY).get();
+        if (config == null) {
+            out.add(in.retain());
+            return;
+        }
+
+        int claimedUncompressedSize = this.helper.readVarInt(in);
         if (claimedUncompressedSize == 0) {
             out.add(in.retain());
             return;
         }
 
-        if (validateDecompression) {
-            if (claimedUncompressedSize < this.session.getCompressionThreshold()) {
-                throw new DecoderException("Badly compressed packet - size of " + claimedUncompressedSize + " is below server threshold of " + this.session.getCompressionThreshold());
+        if (config.validateDecompression()) {
+            if (claimedUncompressedSize < config.threshold()) {
+                throw new DecoderException("Badly compressed packet - size of " + claimedUncompressedSize + " is below server threshold of " + config.threshold());
             }
 
             if (claimedUncompressedSize > MAX_UNCOMPRESSED_SIZE) {
@@ -67,7 +78,7 @@ public class TcpPacketCompression extends MessageToMessageCodec<ByteBuf, ByteBuf
 
         ByteBuf uncompressed = ctx.alloc().directBuffer(claimedUncompressedSize);
         try {
-            compression.inflate(in, uncompressed, claimedUncompressedSize);
+            config.compression().inflate(in, uncompressed, claimedUncompressedSize);
             out.add(uncompressed);
         } catch (Exception e) {
             uncompressed.release();

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpPacketEncryptor.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpPacketEncryptor.java
@@ -6,26 +6,27 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.EncoderException;
 import io.netty.handler.codec.MessageToMessageCodec;
-import org.geysermc.mcprotocollib.network.crypt.PacketEncryption;
+import org.geysermc.mcprotocollib.network.NetworkConstants;
+import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 
 import java.util.List;
 
 public class TcpPacketEncryptor extends MessageToMessageCodec<ByteBuf, ByteBuf> {
-    private final PacketEncryption encryption;
-
-    public TcpPacketEncryptor(PacketEncryption encryption) {
-        this.encryption = encryption;
-    }
-
     @Override
     public void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) {
+        EncryptionConfig config = ctx.channel().attr(NetworkConstants.ENCRYPTION_ATTRIBUTE_KEY).get();
+        if (config == null) {
+            out.add(msg.retain());
+            return;
+        }
+
         ByteBuf heapBuf = this.ensureHeapBuffer(ctx.alloc(), msg);
 
         int inBytes = heapBuf.readableBytes();
         int baseOffset = heapBuf.arrayOffset() + heapBuf.readerIndex();
 
         try {
-            encryption.encrypt(heapBuf.array(), baseOffset, inBytes, heapBuf.array(), baseOffset);
+            config.encryption().encrypt(heapBuf.array(), baseOffset, inBytes, heapBuf.array(), baseOffset);
             out.add(heapBuf);
         } catch (Exception e) {
             heapBuf.release();
@@ -35,13 +36,19 @@ public class TcpPacketEncryptor extends MessageToMessageCodec<ByteBuf, ByteBuf> 
 
     @Override
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
+        EncryptionConfig config = ctx.channel().attr(NetworkConstants.ENCRYPTION_ATTRIBUTE_KEY).get();
+        if (config == null) {
+            out.add(in.retain());
+            return;
+        }
+
         ByteBuf heapBuf = this.ensureHeapBuffer(ctx.alloc(), in).slice();
 
         int inBytes = heapBuf.readableBytes();
         int baseOffset = heapBuf.arrayOffset() + heapBuf.readerIndex();
 
         try {
-            encryption.decrypt(heapBuf.array(), baseOffset, inBytes, heapBuf.array(), baseOffset);
+            config.encryption().decrypt(heapBuf.array(), baseOffset, inBytes, heapBuf.array(), baseOffset);
             out.add(heapBuf);
         } catch (Exception e) {
             heapBuf.release();

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpServer.java
@@ -64,7 +64,9 @@ public class TcpServer extends AbstractServer {
                 pipeline.addLast("read-timeout", new ReadTimeoutHandler(session.getFlag(BuiltinFlags.READ_TIMEOUT, 30)));
                 pipeline.addLast("write-timeout", new WriteTimeoutHandler(session.getFlag(BuiltinFlags.WRITE_TIMEOUT, 0)));
 
+                pipeline.addLast("encryption", new TcpPacketEncryptor());
                 pipeline.addLast("sizer", new TcpPacketSizer(protocol.getPacketHeader(), session.getCodecHelper()));
+                pipeline.addLast("compression", new TcpPacketCompression(session.getCodecHelper()));
 
                 pipeline.addLast("codec", new TcpPacketCodec(session, false));
                 pipeline.addLast("manager", session);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
@@ -187,7 +187,7 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
     }
 
     @Override
-    public void setCompression(CompressionConfig compressionConfig) {
+    public void setCompression(@Nullable CompressionConfig compressionConfig) {
         if (this.channel == null) {
             throw new IllegalStateException("You need to connect to set the compression!");
         }
@@ -196,9 +196,9 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
     }
 
     @Override
-    public void setEncryption(EncryptionConfig encryptionConfig) {
+    public void setEncryption(@Nullable EncryptionConfig encryptionConfig) {
         if (channel == null) {
-            throw new IllegalStateException("You need to connect to enable encryption!");
+            throw new IllegalStateException("You need to connect to set the encryption!");
         }
 
         channel.attr(NetworkConstants.ENCRYPTION_ATTRIBUTE_KEY).set(encryptionConfig);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
@@ -12,9 +12,10 @@ import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.mcprotocollib.network.Flag;
+import org.geysermc.mcprotocollib.network.NetworkConstants;
 import org.geysermc.mcprotocollib.network.Session;
-import org.geysermc.mcprotocollib.network.compression.ZlibCompression;
-import org.geysermc.mcprotocollib.network.crypt.PacketEncryption;
+import org.geysermc.mcprotocollib.network.compression.CompressionConfig;
+import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 import org.geysermc.mcprotocollib.network.event.session.ConnectedEvent;
 import org.geysermc.mcprotocollib.network.event.session.DisconnectedEvent;
 import org.geysermc.mcprotocollib.network.event.session.DisconnectingEvent;
@@ -46,8 +47,6 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
     protected int port;
     private final PacketProtocol protocol;
     private final EventLoop eventLoop = createEventLoop();
-
-    private int compressionThreshold = -1;
 
     private final Map<String, Object> flags = new HashMap<>();
     private final List<SessionListener> listeners = new CopyOnWriteArrayList<>();
@@ -188,31 +187,21 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
     }
 
     @Override
-    public int getCompressionThreshold() {
-        return this.compressionThreshold;
-    }
-
-    @Override
-    public void setCompressionThreshold(int threshold, boolean validateDecompression) {
-        this.compressionThreshold = threshold;
-        if (this.channel != null) {
-            if (this.compressionThreshold >= 0) {
-                if (this.channel.pipeline().get("compression") == null) {
-                    this.channel.pipeline().addBefore("codec", "compression",
-                        new TcpPacketCompression(this, new ZlibCompression(), validateDecompression));
-                }
-            } else if (this.channel.pipeline().get("compression") != null) {
-                this.channel.pipeline().remove("compression");
-            }
+    public void setCompression(CompressionConfig compressionConfig) {
+        if (this.channel == null) {
+            throw new IllegalStateException("You need to be connected to set the compression!");
         }
+
+        channel.attr(NetworkConstants.COMPRESSION_ATTRIBUTE_KEY).set(compressionConfig);
     }
 
     @Override
-    public void enableEncryption(PacketEncryption encryption) {
+    public void setEncryption(EncryptionConfig encryptionConfig) {
         if (channel == null) {
-            throw new IllegalStateException("Connect the client before initializing encryption!");
+            throw new IllegalStateException("You need to connect to enable encryption!");
         }
-        channel.pipeline().addBefore("sizer", "encryption", new TcpPacketEncryptor(encryption));
+
+        channel.attr(NetworkConstants.ENCRYPTION_ATTRIBUTE_KEY).set(encryptionConfig);
     }
 
     @Override
@@ -267,7 +256,7 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
             // daemon threads and their interaction with the runtime.
             PACKET_EVENT_LOOP = new DefaultEventLoopGroup(new DefaultThreadFactory(this.getClass(), true));
             Runtime.getRuntime().addShutdownHook(new Thread(
-                    () -> PACKET_EVENT_LOOP.shutdownGracefully(SHUTDOWN_QUIET_PERIOD_MS, SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)));
+                () -> PACKET_EVENT_LOOP.shutdownGracefully(SHUTDOWN_QUIET_PERIOD_MS, SHUTDOWN_TIMEOUT_MS, TimeUnit.MILLISECONDS)));
         }
         return PACKET_EVENT_LOOP.next();
     }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
@@ -24,6 +24,8 @@ import org.geysermc.mcprotocollib.network.event.session.SessionEvent;
 import org.geysermc.mcprotocollib.network.event.session.SessionListener;
 import org.geysermc.mcprotocollib.network.packet.Packet;
 import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.SocketAddress;
 import java.util.Collections;
@@ -35,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> implements Session {
+    private static final Logger log = LoggerFactory.getLogger(TcpSession.class);
+
     /**
      * Controls whether non-priority packets are handled in a separate event loop
      */
@@ -192,6 +196,7 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
             throw new IllegalStateException("You need to connect to set the compression!");
         }
 
+        log.debug("Setting compression for session {}", this);
         channel.attr(NetworkConstants.COMPRESSION_ATTRIBUTE_KEY).set(compressionConfig);
     }
 
@@ -201,6 +206,7 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
             throw new IllegalStateException("You need to connect to set the encryption!");
         }
 
+        log.debug("Setting encryption for session {}", this);
         channel.attr(NetworkConstants.ENCRYPTION_ATTRIBUTE_KEY).set(encryptionConfig);
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpSession.java
@@ -189,7 +189,7 @@ public abstract class TcpSession extends SimpleChannelInboundHandler<Packet> imp
     @Override
     public void setCompression(CompressionConfig compressionConfig) {
         if (this.channel == null) {
-            throw new IllegalStateException("You need to be connected to set the compression!");
+            throw new IllegalStateException("You need to connect to set the compression!");
         }
 
         channel.attr(NetworkConstants.COMPRESSION_ATTRIBUTE_KEY).set(compressionConfig);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
@@ -7,6 +7,8 @@ import net.kyori.adventure.text.Component;
 import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.auth.SessionService;
 import org.geysermc.mcprotocollib.network.Session;
+import org.geysermc.mcprotocollib.network.compression.CompressionConfig;
+import org.geysermc.mcprotocollib.network.compression.ZlibCompression;
 import org.geysermc.mcprotocollib.network.event.session.ConnectedEvent;
 import org.geysermc.mcprotocollib.network.event.session.SessionAdapter;
 import org.geysermc.mcprotocollib.network.packet.Packet;
@@ -91,13 +93,14 @@ public class ClientListener extends SessionAdapter {
                 }
 
                 session.send(new ServerboundKeyPacket(helloPacket.getPublicKey(), key, helloPacket.getChallenge()));
-                session.enableEncryption(protocol.enableEncryption(key));
+                session.setEncryption(protocol.enableEncryption(key));
             } else if (packet instanceof ClientboundGameProfilePacket) {
                 session.send(new ServerboundLoginAcknowledgedPacket());
             } else if (packet instanceof ClientboundLoginDisconnectPacket loginDisconnectPacket) {
                 session.disconnect(loginDisconnectPacket.getReason());
             } else if (packet instanceof ClientboundLoginCompressionPacket loginCompressionPacket) {
-                session.setCompressionThreshold(loginCompressionPacket.getThreshold(), false);
+                session.setCompression(loginCompressionPacket.getThreshold() >= 0 ?
+                    new CompressionConfig(loginCompressionPacket.getThreshold(), new ZlibCompression(), false) : null);
             }
         } else if (protocol.getState() == ProtocolState.STATUS) {
             if (packet instanceof ClientboundStatusResponsePacket statusResponsePacket) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
@@ -93,7 +93,7 @@ public class ClientListener extends SessionAdapter {
                 }
 
                 session.send(new ServerboundKeyPacket(helloPacket.getPublicKey(), key, helloPacket.getChallenge()));
-                session.setEncryption(protocol.enableEncryption(key));
+                session.setEncryption(protocol.createEncryption(key));
             } else if (packet instanceof ClientboundGameProfilePacket) {
                 session.send(new ServerboundLoginAcknowledgedPacket());
             } else if (packet instanceof ClientboundLoginDisconnectPacket loginDisconnectPacket) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
@@ -99,8 +99,9 @@ public class ClientListener extends SessionAdapter {
             } else if (packet instanceof ClientboundLoginDisconnectPacket loginDisconnectPacket) {
                 session.disconnect(loginDisconnectPacket.getReason());
             } else if (packet instanceof ClientboundLoginCompressionPacket loginCompressionPacket) {
-                session.setCompression(loginCompressionPacket.getThreshold() >= 0 ?
-                    new CompressionConfig(loginCompressionPacket.getThreshold(), new ZlibCompression(), false) : null);
+                int threshold = loginCompressionPacket.getThreshold();
+                session.setCompression(threshold >= 0 ?
+                    new CompressionConfig(threshold, new ZlibCompression(), false) : null);
             }
         } else if (protocol.getState() == ProtocolState.STATUS) {
             if (packet instanceof ClientboundStatusResponsePacket statusResponsePacket) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftConstants.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftConstants.java
@@ -63,9 +63,14 @@ public final class MinecraftConstants {
     // Server Key Constants
 
     /**
-     * Session flag for determining whether to verify users. Server only.
+     * Session flag for determining whether to encrypt the connection. Server only.
      */
-    public static final Flag<Boolean> VERIFY_USERS_KEY = new Flag<>("verify-users", Boolean.class);
+    public static final Flag<Boolean> ENCRYPT_CONNECTION = new Flag<>("encrypt-connection", Boolean.class);
+
+    /**
+     * Session flag for determining whether to authenticate users with the session service. Server only.
+     */
+    public static final Flag<Boolean> SHOULD_AUTHENTICATE = new Flag<>("should-authenticate", Boolean.class);
 
     /**
      * Session flag for determining whether to accept transferred connections. Server only.

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocol.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocol.java
@@ -177,7 +177,7 @@ public class MinecraftProtocol extends PacketProtocol {
         return this.stateRegistry;
     }
 
-    protected EncryptionConfig enableEncryption(Key key) {
+    protected EncryptionConfig createEncryption(Key key) {
         try {
             return new EncryptionConfig(new AESEncryption(key));
         } catch (GeneralSecurityException e) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocol.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocol.java
@@ -181,7 +181,7 @@ public class MinecraftProtocol extends PacketProtocol {
         try {
             return new EncryptionConfig(new AESEncryption(key));
         } catch (GeneralSecurityException e) {
-            throw new IllegalStateException("Failed to enable protocol encryption.", e);
+            throw new IllegalStateException("Failed to create protocol encryption.", e);
         }
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocol.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocol.java
@@ -10,7 +10,7 @@ import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.network.Server;
 import org.geysermc.mcprotocollib.network.Session;
 import org.geysermc.mcprotocollib.network.crypt.AESEncryption;
-import org.geysermc.mcprotocollib.network.crypt.PacketEncryption;
+import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 import org.geysermc.mcprotocollib.network.packet.PacketHeader;
 import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.packet.PacketRegistry;
@@ -177,11 +177,11 @@ public class MinecraftProtocol extends PacketProtocol {
         return this.stateRegistry;
     }
 
-    protected PacketEncryption enableEncryption(Key key) {
+    protected EncryptionConfig enableEncryption(Key key) {
         try {
-            return new AESEncryption(key);
+            return new EncryptionConfig(new AESEncryption(key));
         } catch (GeneralSecurityException e) {
-            throw new Error("Failed to enable protocol encryption.", e);
+            throw new IllegalStateException("Failed to enable protocol encryption.", e);
         }
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -8,6 +8,8 @@ import org.cloudburstmc.nbt.NbtType;
 import org.geysermc.mcprotocollib.auth.GameProfile;
 import org.geysermc.mcprotocollib.auth.SessionService;
 import org.geysermc.mcprotocollib.network.Session;
+import org.geysermc.mcprotocollib.network.compression.CompressionConfig;
+import org.geysermc.mcprotocollib.network.compression.ZlibCompression;
 import org.geysermc.mcprotocollib.network.event.session.ConnectedEvent;
 import org.geysermc.mcprotocollib.network.event.session.DisconnectingEvent;
 import org.geysermc.mcprotocollib.network.event.session.SessionAdapter;
@@ -129,7 +131,7 @@ public class ServerListener extends SessionAdapter {
                 }
 
                 SecretKey key = keyPacket.getSecretKey(privateKey);
-                session.enableEncryption(protocol.enableEncryption(key));
+                session.setEncryption(protocol.enableEncryption(key));
                 new Thread(new UserAuthTask(session, key)).start();
             } else if (packet instanceof ServerboundLoginAcknowledgedPacket) {
                 protocol.setState(ProtocolState.CONFIGURATION);
@@ -202,7 +204,7 @@ public class ServerListener extends SessionAdapter {
     @Override
     public void packetSent(Session session, Packet packet) {
         if (packet instanceof ClientboundLoginCompressionPacket loginCompressionPacket) {
-            session.setCompressionThreshold(loginCompressionPacket.getThreshold(), true);
+            session.setCompression(new CompressionConfig(loginCompressionPacket.getThreshold(), new ZlibCompression(), true));
             session.send(new ClientboundGameProfilePacket(session.getFlag(MinecraftConstants.PROFILE_KEY), true));
         }
     }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -204,7 +204,9 @@ public class ServerListener extends SessionAdapter {
     @Override
     public void packetSent(Session session, Packet packet) {
         if (packet instanceof ClientboundLoginCompressionPacket loginCompressionPacket) {
-            session.setCompression(new CompressionConfig(loginCompressionPacket.getThreshold(), new ZlibCompression(), true));
+            int threshold = loginCompressionPacket.getThreshold();
+            session.setCompression(threshold >= 0 ?
+                new CompressionConfig(threshold, new ZlibCompression(), true) : null);
             session.send(new ClientboundGameProfilePacket(session.getFlag(MinecraftConstants.PROFILE_KEY), true));
         }
     }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -131,7 +131,7 @@ public class ServerListener extends SessionAdapter {
                 }
 
                 SecretKey key = keyPacket.getSecretKey(privateKey);
-                session.setEncryption(protocol.enableEncryption(key));
+                session.setEncryption(protocol.createEncryption(key));
                 new Thread(new UserAuthTask(session, key)).start();
             } else if (packet instanceof ServerboundLoginAcknowledgedPacket) {
                 protocol.setState(ProtocolState.CONFIGURATION);

--- a/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocolTest.java
+++ b/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocolTest.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
-import static org.geysermc.mcprotocollib.protocol.MinecraftConstants.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class MinecraftProtocolTest {
@@ -49,10 +48,11 @@ public class MinecraftProtocolTest {
     @BeforeAll
     public static void setupServer() {
         server = new TcpServer(HOST, PORT, MinecraftProtocol::new);
-        server.setGlobalFlag(VERIFY_USERS_KEY, false);
-        server.setGlobalFlag(SERVER_COMPRESSION_THRESHOLD, 100);
-        server.setGlobalFlag(SERVER_INFO_BUILDER_KEY, session -> SERVER_INFO);
-        server.setGlobalFlag(SERVER_LOGIN_HANDLER_KEY, session -> {
+        server.setGlobalFlag(MinecraftConstants.ENCRYPT_CONNECTION, true);
+        server.setGlobalFlag(MinecraftConstants.SHOULD_AUTHENTICATE, false);
+        server.setGlobalFlag(MinecraftConstants.SERVER_COMPRESSION_THRESHOLD, 256);
+        server.setGlobalFlag(MinecraftConstants.SERVER_INFO_BUILDER_KEY, session -> SERVER_INFO);
+        server.setGlobalFlag(MinecraftConstants.SERVER_LOGIN_HANDLER_KEY, session -> {
             // Seems like in this setup the server can reply too quickly to ServerboundFinishConfigurationPacket
             // before the client can transition CONFIGURATION -> GAME. There is probably something wrong here and this is just a band-aid.
             try {
@@ -79,7 +79,7 @@ public class MinecraftProtocolTest {
         Session session = new TcpClientSession(HOST, PORT, new MinecraftProtocol());
         try {
             ServerInfoHandlerTest handler = new ServerInfoHandlerTest();
-            session.setFlag(SERVER_INFO_HANDLER_KEY, handler);
+            session.setFlag(MinecraftConstants.SERVER_INFO_HANDLER_KEY, handler);
             session.addListener(new DisconnectListener());
             session.connect();
 


### PR DESCRIPTION
This builds up on the static sizer and timeout PR: https://github.com/GeyserMC/MCProtocolLib/pull/833
The reason compression and encryption should be static is to avoid confusion about the pipeline dynamically changing. This also allows more customization by developers who want to use alternative compression algorithms like igzip.