### PR TITLE
Allow accessing backing class for a channel instead of only its factory

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/helper/TransportHelper.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/helper/TransportHelper.java
@@ -34,8 +34,11 @@ public class TransportHelper {
     }
 
     public record TransportType(TransportMethod method,
+                                Class<? extends ServerSocketChannel> serverSocketChannelClass,
                                 ChannelFactory<? extends ServerSocketChannel> serverSocketChannelFactory,
+                                Class<? extends SocketChannel> socketChannelClass,
                                 ChannelFactory<? extends SocketChannel> socketChannelFactory,
+                                Class<? extends DatagramChannel> datagramChannelClass,
                                 ChannelFactory<? extends DatagramChannel> datagramChannelFactory,
                                 Function<ThreadFactory, EventLoopGroup> eventLoopGroupFactory,
                                 boolean supportsTcpFastOpenServer,
@@ -46,8 +49,11 @@ public class TransportHelper {
         if (isClassAvailable("io.netty.incubator.channel.uring.IOUring") && IOUring.isAvailable()) {
             return new TransportType(
                     TransportMethod.IO_URING,
+                    IOUringServerSocketChannel.class,
                     IOUringServerSocketChannel::new,
+                    IOUringSocketChannel.class,
                     IOUringSocketChannel::new,
+                    IOUringDatagramChannel.class,
                     IOUringDatagramChannel::new,
                     factory -> new IOUringEventLoopGroup(0, factory),
                     IOUring.isTcpFastOpenServerSideAvailable(),
@@ -58,8 +64,11 @@ public class TransportHelper {
         if (isClassAvailable("io.netty.channel.epoll.Epoll") && Epoll.isAvailable()) {
             return new TransportType(
                     TransportMethod.EPOLL,
+                    EpollServerSocketChannel.class,
                     EpollServerSocketChannel::new,
+                    EpollSocketChannel.class,
                     EpollSocketChannel::new,
+                    EpollDatagramChannel.class,
                     EpollDatagramChannel::new,
                     factory -> new EpollEventLoopGroup(0, factory),
                     Epoll.isTcpFastOpenServerSideAvailable(),
@@ -70,8 +79,11 @@ public class TransportHelper {
         if (isClassAvailable("io.netty.channel.kqueue.KQueue") && KQueue.isAvailable()) {
             return new TransportType(
                     TransportMethod.KQUEUE,
+                    KQueueServerSocketChannel.class,
                     KQueueServerSocketChannel::new,
+                    KQueueSocketChannel.class,
                     KQueueSocketChannel::new,
+                    KQueueDatagramChannel.class,
                     KQueueDatagramChannel::new,
                     factory -> new KQueueEventLoopGroup(0, factory),
                     KQueue.isTcpFastOpenServerSideAvailable(),
@@ -81,8 +93,11 @@ public class TransportHelper {
 
         return new TransportType(
                 TransportMethod.NIO,
+                NioServerSocketChannel.class,
                 NioServerSocketChannel::new,
+                NioSocketChannel.class,
                 NioSocketChannel::new,
+                NioDatagramChannel.class,
                 NioDatagramChannel::new,
                 factory -> new NioEventLoopGroup(0, factory),
                 false,


### PR DESCRIPTION
Some netty libraries that are poorly coded only accept classes. Example: https://github.com/CloudburstMC/Network/pull/42