### PR TITLE
Fix/proxy protocol

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/tcp/TcpClientSession.java
@@ -199,7 +199,8 @@ public class TcpClientSession extends TcpSession {
             log.debug("Resolved {} -> {}", getHost(), resolved.getHostAddress());
             return new InetSocketAddress(resolved, getPort());
         } catch (UnknownHostException e) {
-            throw new IllegalStateException("Failed to resolve host.", e);
+            log.debug("Failed to resolve host, letting Netty do it instead.", e);
+            return InetSocketAddress.createUnresolved(getHost(), getPort());
         }
     }
 


### PR DESCRIPTION
[Fix haproxy not having a working remote address](https://github.com/GeyserMC/MCProtocolLib/commit/187a306b867f99df33d20ff9d62b0fbdadfebd96)

Netty resolving is removed, if we can't resolve an address, netty can't either. The main difference is that netty may resolve addresses using an incorrect dns server/proxy unlike our code where we keep full control of the dns server and other things used to resolve addresses like users want us to resolve them.