### PR TITLE
Fix equippable component writing

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/ItemCodecHelper.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/ItemCodecHelper.java
@@ -158,6 +158,7 @@ public class ItemCodecHelper extends MinecraftCodecHelper {
         }
 
         this.writeNullable(buf, equippable.model(), this::writeResourceLocation);
+        this.writeNullable(buf, equippable.cameraOverlay(), this::writeResourceLocation);
         this.writeNullable(buf, equippable.allowedEntities(), this::writeHolderSet);
         buf.writeBoolean(equippable.dispensable());
         buf.writeBoolean(equippable.swappable());


### PR DESCRIPTION
This PR fixes the `minecraft:equippable` item data component not writing the camera overlay property.

On Geyser, this issue was causing Bedrock players to be kicked when trying to move an item with the equippable component in the inventory. I've tested and confirmed that this is fixed with this PR.