### PR TITLE
Improve clarity of unbreakable component

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentType.java
@@ -25,7 +25,7 @@ public class DataComponentType<T> {
     public static final IntComponentType MAX_STACK_SIZE = new IntComponentType("max_stack_size", ItemCodecHelper::readVarInt, ItemCodecHelper::writeVarInt, IntDataComponent::new);
     public static final IntComponentType MAX_DAMAGE = new IntComponentType("max_damage", ItemCodecHelper::readVarInt, ItemCodecHelper::writeVarInt, IntDataComponent::new);
     public static final IntComponentType DAMAGE = new IntComponentType("damage", ItemCodecHelper::readVarInt, ItemCodecHelper::writeVarInt, IntDataComponent::new);
-    public static final BooleanComponentType UNBREAKABLE = new BooleanComponentType("unbreakable", ByteBuf::readBoolean, ByteBuf::writeBoolean, BooleanDataComponent::new);
+    public static final DataComponentType<Unbreakable> UNBREAKABLE = new DataComponentType<>("unbreakable", ItemCodecHelper::readUnbreakable, ItemCodecHelper::writeUnbreakable, ObjectDataComponent::new);
     public static final DataComponentType<Component> CUSTOM_NAME = new DataComponentType<>("custom_name", ItemCodecHelper::readComponent, ItemCodecHelper::writeComponent, ObjectDataComponent::new);
     public static final DataComponentType<Component> ITEM_NAME = new DataComponentType<>("item_name", ItemCodecHelper::readComponent, ItemCodecHelper::writeComponent, ObjectDataComponent::new);
     public static final DataComponentType<Key> ITEM_MODEL = new DataComponentType<>("item_model", ItemCodecHelper::readResourceLocation, ItemCodecHelper::writeResourceLocation, ObjectDataComponent::new);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/ItemCodecHelper.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/ItemCodecHelper.java
@@ -38,6 +38,14 @@ public class ItemCodecHelper extends MinecraftCodecHelper {
         this.writeNullable(buf, filterable.getOptional(), writer);
     }
 
+    public Unbreakable readUnbreakable(ByteBuf buf) {
+        return new Unbreakable(buf.readBoolean());
+    }
+
+    public void writeUnbreakable(ByteBuf buf, Unbreakable unbreakable) {
+        buf.writeBoolean(unbreakable.isInTooltip());
+    }
+
     public ItemEnchantments readItemEnchantments(ByteBuf buf) {
         Map<Integer, Integer> enchantments = new HashMap<>();
         int enchantmentCount = this.readVarInt(buf);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/Unbreakable.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/Unbreakable.java
@@ -1,0 +1,10 @@
+package org.geysermc.mcprotocollib.protocol.data.game.item.component;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class Unbreakable {
+    private boolean inTooltip;
+}


### PR DESCRIPTION
This PR improves the clarity of the `UNBREAKABLE` data component, by wrapping the `show_in_tooltip` value in a simple wrapper class.

Before, the component was a bit misleading because it directly exposed this value as a boolean:

> `components.get(DataComponentType.UNBREAKABLE)` -> whether the component should be shown in tooltip
> `components.get(DataComponentType.UNBREAKABLE) != null` -> whether the item is unbreakable

Now, this is a bit clearer:

> `components.get(DataComponentType.UNBREAKABLE).isInTooltip()` -> whether the component should be shown in tooltip
> `components.get(DataComponentType.UNBREAKABLE) != null` -> whether the item is unbreakable