### PR TITLE
Rewrite some internal code to allow better disconnect handling

### DIFF
--- a/example/src/main/java/org/geysermc/mcprotocollib/network/example/ClientSessionListener.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/network/example/ClientSessionListener.java
@@ -45,11 +45,11 @@ public class ClientSessionListener extends SessionAdapter {
 
     @Override
     public void disconnecting(DisconnectingEvent event) {
-        log.info("CLIENT Disconnecting: {}", event.getReason());
+        log.info("CLIENT Disconnecting: {}", event.getDetails().reason());
     }
 
     @Override
     public void disconnected(DisconnectedEvent event) {
-        log.info("CLIENT Disconnected: {}", event.getReason());
+        log.info("CLIENT Disconnected: {}", event.getDetails().reason());
     }
 }

--- a/example/src/main/java/org/geysermc/mcprotocollib/network/example/ServerSessionListener.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/network/example/ServerSessionListener.java
@@ -34,11 +34,11 @@ public class ServerSessionListener extends SessionAdapter {
 
     @Override
     public void disconnecting(DisconnectingEvent event) {
-        log.info("SERVER Disconnecting: {}", event.getReason());
+        log.info("SERVER Disconnecting: {}", event.getDetails().reason());
     }
 
     @Override
     public void disconnected(DisconnectedEvent event) {
-        log.info("SERVER Disconnected: {}", event.getReason());
+        log.info("SERVER Disconnected: {}", event.getDetails().reason());
     }
 }

--- a/example/src/main/java/org/geysermc/mcprotocollib/network/example/TestProtocol.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/network/example/TestProtocol.java
@@ -9,8 +9,8 @@ import org.geysermc.mcprotocollib.network.crypt.AESEncryption;
 import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 import org.geysermc.mcprotocollib.network.packet.DefaultPacketHeader;
 import org.geysermc.mcprotocollib.network.packet.PacketHeader;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.packet.PacketRegistry;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 import org.geysermc.mcprotocollib.protocol.codec.MinecraftTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import javax.crypto.SecretKey;
 import java.security.GeneralSecurityException;
 
-public class TestProtocol extends PacketProtocol {
+public class TestProtocol extends MinecraftProtocol {
     private static final Logger log = LoggerFactory.getLogger(TestProtocol.class);
     private final PacketHeader header = new DefaultPacketHeader();
     private final PacketRegistry registry = new PacketRegistry();

--- a/example/src/main/java/org/geysermc/mcprotocollib/protocol/example/MinecraftProtocolTest.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/protocol/example/MinecraftProtocolTest.java
@@ -230,7 +230,7 @@ public class MinecraftProtocolTest {
 
             @Override
             public void disconnected(DisconnectedEvent event) {
-                log.info("Disconnected: {}", event.getReason(), event.getCause());
+                log.info("Disconnected: {}", event.getDetails().reason(), event.getDetails().cause());
             }
         });
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/PacketFlow.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/PacketFlow.java
@@ -1,0 +1,10 @@
+package org.geysermc.mcprotocollib.network;
+
+public enum PacketFlow {
+    SERVERBOUND,
+    CLIENTBOUND;
+
+    public PacketFlow opposite() {
+        return this == CLIENTBOUND ? SERVERBOUND : CLIENTBOUND;
+    }
+}

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/event/session/DisconnectedEvent.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/event/session/DisconnectedEvent.java
@@ -1,27 +1,24 @@
 package org.geysermc.mcprotocollib.network.event.session;
 
-import net.kyori.adventure.text.Component;
 import org.geysermc.mcprotocollib.network.Session;
+import org.geysermc.mcprotocollib.network.helper.DisconnectionDetails;
 
 /**
  * Called when the session is disconnected.
  */
 public class DisconnectedEvent implements SessionEvent {
     private final Session session;
-    private final Component reason;
-    private final Throwable cause;
+    private final DisconnectionDetails disconnectionDetails;
 
     /**
      * Creates a new DisconnectedEvent instance.
      *
      * @param session Session being disconnected.
-     * @param reason Reason for the session to disconnect.
-     * @param cause Throwable that caused the disconnect.
+     * @param disconnectionDetails Reason for the disconnection.
      */
-    public DisconnectedEvent(Session session, Component reason, Throwable cause) {
+    public DisconnectedEvent(Session session, DisconnectionDetails disconnectionDetails) {
         this.session = session;
-        this.reason = reason;
-        this.cause = cause;
+        this.disconnectionDetails = disconnectionDetails;
     }
 
     /**
@@ -38,17 +35,8 @@ public class DisconnectedEvent implements SessionEvent {
      *
      * @return The event's reason.
      */
-    public Component getReason() {
-        return this.reason;
-    }
-
-    /**
-     * Gets the Throwable responsible for the session disconnecting.
-     *
-     * @return The Throwable responsible for the disconnect, or null if the disconnect was not caused by a Throwable.
-     */
-    public Throwable getCause() {
-        return this.cause;
+    public DisconnectionDetails getDetails() {
+        return this.disconnectionDetails;
     }
 
     @Override

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/event/session/DisconnectingEvent.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/event/session/DisconnectingEvent.java
@@ -1,27 +1,24 @@
 package org.geysermc.mcprotocollib.network.event.session;
 
-import net.kyori.adventure.text.Component;
 import org.geysermc.mcprotocollib.network.Session;
+import org.geysermc.mcprotocollib.network.helper.DisconnectionDetails;
 
 /**
  * Called when the session is about to disconnect.
  */
 public class DisconnectingEvent implements SessionEvent {
     private final Session session;
-    private final Component reason;
-    private final Throwable cause;
+    private final DisconnectionDetails disconnectionDetails;
 
     /**
      * Creates a new DisconnectingEvent instance.
      *
      * @param session Session being disconnected.
-     * @param reason Reason for the session to disconnect.
-     * @param cause Throwable that caused the disconnect.
+     * @param disconnectionDetails Reason for the disconnection.
      */
-    public DisconnectingEvent(Session session, Component reason, Throwable cause) {
+    public DisconnectingEvent(Session session, DisconnectionDetails disconnectionDetails) {
         this.session = session;
-        this.reason = reason;
-        this.cause = cause;
+        this.disconnectionDetails = disconnectionDetails;
     }
 
     /**
@@ -38,17 +35,8 @@ public class DisconnectingEvent implements SessionEvent {
      *
      * @return The event's reason.
      */
-    public Component getReason() {
-        return this.reason;
-    }
-
-    /**
-     * Gets the Throwable responsible for the session disconnecting.
-     *
-     * @return The Throwable responsible for the disconnect, or null if the disconnect was not caused by a Throwable.
-     */
-    public Throwable getCause() {
-        return this.cause;
+    public DisconnectionDetails getDetails() {
+        return this.disconnectionDetails;
     }
 
     @Override

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/event/session/PacketSendingEvent.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/event/session/PacketSendingEvent.java
@@ -34,14 +34,12 @@ public class PacketSendingEvent implements SessionEvent {
     /**
      * Gets the packet involved in this event as the required type.
      *
-     * @param <T> Type of the packet.
      * @return The event's packet as the required type.
      * @throws IllegalStateException If the packet's value isn't of the required type.
      */
-    @SuppressWarnings("unchecked")
-    public <T extends Packet> T getPacket() {
+    public Packet getPacket() {
         try {
-            return (T) this.packet;
+            return this.packet;
         } catch (ClassCastException e) {
             throw new IllegalStateException("Tried to get packet as the wrong type. Actual type: " + this.packet.getClass().getName());
         }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/factory/ClientNetworkSessionFactory.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/factory/ClientNetworkSessionFactory.java
@@ -5,8 +5,8 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.geysermc.mcprotocollib.network.ProxyInfo;
 import org.geysermc.mcprotocollib.network.netty.DefaultPacketHandlerExecutor;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.session.ClientNetworkSession;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -18,7 +18,7 @@ import java.util.concurrent.Executor;
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public final class ClientNetworkSessionFactory {
     private SocketAddress remoteSocketAddress;
-    private PacketProtocol protocol;
+    private MinecraftProtocol protocol;
     private Executor packetHandlerExecutor;
     private SocketAddress bindSocketAddress;
     private ProxyInfo proxy;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/helper/DisconnectionDetails.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/helper/DisconnectionDetails.java
@@ -1,0 +1,11 @@
+package org.geysermc.mcprotocollib.network.helper;
+
+import net.kyori.adventure.text.Component;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public record DisconnectionDetails(@NonNull Component reason, @Nullable Throwable cause) {
+    public DisconnectionDetails(@NonNull Component reason) {
+        this(reason, null);
+    }
+}

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/packet/PacketRegistry.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/packet/PacketRegistry.java
@@ -105,9 +105,8 @@ public class PacketRegistry {
      * @return The created packet.
      * @throws IllegalArgumentException If the packet ID is not registered.
      */
-    @SuppressWarnings("unchecked")
     public Packet createClientboundPacket(int id, ByteBuf buf) {
-        PacketDefinition<?> definition = (PacketDefinition<?>) this.clientbound.get(id);
+        PacketDefinition<?> definition = this.clientbound.get(id);
         if (definition == null) {
             throw new IllegalArgumentException("Invalid packet id: " + id);
         }
@@ -166,9 +165,8 @@ public class PacketRegistry {
      * @return The created packet.
      * @throws IllegalArgumentException If the packet ID is not registered.
      */
-    @SuppressWarnings("unchecked")
     public Packet createServerboundPacket(int id, ByteBuf buf) {
-        PacketDefinition<?> definition = (PacketDefinition<?>) this.serverbound.get(id);
+        PacketDefinition<?> definition = this.serverbound.get(id);
         if (definition == null) {
             throw new IllegalArgumentException("Invalid packet id: " + id);
         }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/server/AbstractServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/server/AbstractServer.java
@@ -12,6 +12,7 @@ import org.geysermc.mcprotocollib.network.event.server.ServerListener;
 import org.geysermc.mcprotocollib.network.event.server.SessionAddedEvent;
 import org.geysermc.mcprotocollib.network.event.server.SessionRemovedEvent;
 import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.SocketAddress;
 import java.util.ArrayList;
@@ -23,14 +24,14 @@ import java.util.function.Supplier;
 
 public abstract class AbstractServer implements Server {
     private final SocketAddress bindAddress;
-    private final Supplier<? extends PacketProtocol> protocolSupplier;
+    private final Supplier<? extends MinecraftProtocol> protocolSupplier;
 
     private final List<Session> sessions = new ArrayList<>();
 
     private final Map<String, Object> flags = new HashMap<>();
     private final List<ServerListener> listeners = new ArrayList<>();
 
-    public AbstractServer(SocketAddress bindAddress, Supplier<? extends PacketProtocol> protocolSupplier) {
+    public AbstractServer(SocketAddress bindAddress, Supplier<? extends MinecraftProtocol> protocolSupplier) {
         this.bindAddress = bindAddress;
         this.protocolSupplier = protocolSupplier;
     }
@@ -45,7 +46,7 @@ public abstract class AbstractServer implements Server {
         return this.protocolSupplier;
     }
 
-    protected PacketProtocol createPacketProtocol() {
+    protected MinecraftProtocol createPacketProtocol() {
         return this.protocolSupplier.get();
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/server/NetworkServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/server/NetworkServer.java
@@ -12,9 +12,9 @@ import org.geysermc.mcprotocollib.network.BuiltinFlags;
 import org.geysermc.mcprotocollib.network.helper.TransportHelper;
 import org.geysermc.mcprotocollib.network.netty.DefaultPacketHandlerExecutor;
 import org.geysermc.mcprotocollib.network.netty.MinecraftChannelInitializer;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.session.NetworkSession;
 import org.geysermc.mcprotocollib.network.session.ServerNetworkSession;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,11 +31,11 @@ public class NetworkServer extends AbstractServer {
     private EventLoopGroup workerGroup;
     private Channel channel;
 
-    public NetworkServer(SocketAddress bindAddress, Supplier<? extends PacketProtocol> protocol) {
+    public NetworkServer(SocketAddress bindAddress, Supplier<? extends MinecraftProtocol> protocol) {
         this(bindAddress, protocol, DefaultPacketHandlerExecutor::createExecutor);
     }
 
-    public NetworkServer(SocketAddress bindAddress, Supplier<? extends PacketProtocol> protocol, Supplier<Executor> packetHandlerExecutorFactory) {
+    public NetworkServer(SocketAddress bindAddress, Supplier<? extends MinecraftProtocol> protocol, Supplier<Executor> packetHandlerExecutorFactory) {
         super(bindAddress, protocol);
         this.packetHandlerExecutorFactory = packetHandlerExecutorFactory;
     }
@@ -104,7 +104,7 @@ public class NetworkServer extends AbstractServer {
 
     protected ChannelHandler getChannelHandler() {
         return new MinecraftChannelInitializer<>(channel -> {
-            PacketProtocol protocol = createPacketProtocol();
+            MinecraftProtocol protocol = createPacketProtocol();
 
             NetworkSession session = new ServerNetworkSession(channel.remoteAddress(), protocol, NetworkServer.this, packetHandlerExecutorFactory.get());
             session.getPacketProtocol().newServerSession(NetworkServer.this, session);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ClientNetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ClientNetworkSession.java
@@ -11,11 +11,13 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.mcprotocollib.network.BuiltinFlags;
 import org.geysermc.mcprotocollib.network.ClientSession;
+import org.geysermc.mcprotocollib.network.PacketFlow;
 import org.geysermc.mcprotocollib.network.ProxyInfo;
 import org.geysermc.mcprotocollib.network.helper.NettyHelper;
 import org.geysermc.mcprotocollib.network.helper.TransportHelper;
 import org.geysermc.mcprotocollib.network.netty.MinecraftChannelInitializer;
 import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
@@ -37,19 +39,19 @@ public class ClientNetworkSession extends NetworkSession implements ClientSessio
 
     public ClientNetworkSession(
         @NonNull SocketAddress remoteAddress,
-        @NonNull PacketProtocol protocol,
+        @NonNull MinecraftProtocol protocol,
         @NonNull Executor packetHandlerExecutor,
         @Nullable SocketAddress bindAddress,
         @Nullable ProxyInfo proxy
     ) {
-        super(remoteAddress, protocol, packetHandlerExecutor);
+        super(remoteAddress, protocol, packetHandlerExecutor, PacketFlow.CLIENTBOUND);
         this.bindAddress = bindAddress;
         this.proxy = proxy;
     }
 
     @Override
     public void connect(boolean wait) {
-        if (this.disconnected) {
+        if (this.disconnectionHandled) {
             throw new IllegalStateException("Session has already been disconnected.");
         }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ClientNetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ClientNetworkSession.java
@@ -7,6 +7,7 @@ import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
 import io.netty.util.concurrent.DefaultThreadFactory;
+import net.kyori.adventure.text.Component;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.geysermc.mcprotocollib.network.BuiltinFlags;
@@ -69,7 +70,7 @@ public class ClientNetworkSession extends NetworkSession implements ClientSessio
         CompletableFuture<Void> handleFuture = new CompletableFuture<>();
         bootstrap.connect().addListener((futureListener) -> {
             if (!futureListener.isSuccess()) {
-                exceptionCaught(null, futureListener.cause());
+                disconnect(Component.text("Failed to connect"), futureListener.cause());
             }
 
             handleFuture.complete(null);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
@@ -145,7 +145,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
                 event.call(listener);
             }
         } catch (Throwable t) {
-            exceptionCaught(null, t);
+            disconnect(Component.text("Event handler error"), t);
         }
     }
 
@@ -156,7 +156,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
                 listener.packetReceived(this, packet);
             }
         } catch (Throwable t) {
-            exceptionCaught(null, t);
+            disconnect(Component.text("Packet received listener error"), t);
         }
     }
 
@@ -167,7 +167,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
                 listener.packetSent(this, packet);
             }
         } catch (Throwable t) {
-            exceptionCaught(null, t);
+            disconnect(Component.text("Packet sent listener error"), t);
         }
     }
 
@@ -312,7 +312,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
 
     @Override
     public void switchOutboundState(ProtocolState state) {
-        getChannel().writeAndFlush(FlushHandler.FLUSH_PACKET).syncUninterruptibly();
+        channel.writeAndFlush(FlushHandler.FLUSH_PACKET).syncUninterruptibly();
 
         protocol.setOutboundState(state);
         sendLoginDisconnect = state == ProtocolState.LOGIN;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
@@ -227,22 +227,22 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
             this.delayedDisconnect = disconnectionDetails;
         }
 
+        boolean wasDisconnectionHandled = this.disconnectionHandled;
+        if (!wasDisconnectionHandled) {
+            this.disconnectionHandled = true;
+        }
+
+        if (!wasDisconnectionHandled) {
+            this.callEvent(new DisconnectingEvent(this, disconnectionDetails));
+        }
+
         if (this.isConnected()) {
-            boolean wasDisconnectionHandled = this.disconnectionHandled;
-            if (!wasDisconnectionHandled) {
-                this.disconnectionHandled = true;
-            }
-
-            if (!wasDisconnectionHandled) {
-                this.callEvent(new DisconnectingEvent(this, disconnectionDetails));
-            }
-
             this.channel.close().awaitUninterruptibly();
             this.disconnectionDetails = disconnectionDetails;
+        }
 
-            if (!wasDisconnectionHandled) {
-                this.callEvent(new DisconnectedEvent(this, disconnectionDetails));
-            }
+        if (!wasDisconnectionHandled) {
+            this.callEvent(new DisconnectedEvent(this, disconnectionDetails));
         }
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
@@ -273,7 +273,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
         }
     }
 
-    private void flushQueue() {
+    public void flushQueue() {
         if (this.channel != null && this.channel.isOpen()) {
             synchronized (this.pendingActions) {
                 Consumer<NetworkSession> consumer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ServerNetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ServerNetworkSession.java
@@ -2,9 +2,10 @@ package org.geysermc.mcprotocollib.network.session;
 
 import io.netty.channel.ChannelHandlerContext;
 import org.geysermc.mcprotocollib.network.Flag;
+import org.geysermc.mcprotocollib.network.PacketFlow;
 import org.geysermc.mcprotocollib.network.ServerSession;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.server.NetworkServer;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.SocketAddress;
 import java.util.HashMap;
@@ -15,8 +16,8 @@ import java.util.function.Supplier;
 public class ServerNetworkSession extends NetworkSession implements ServerSession {
     private final NetworkServer server;
 
-    public ServerNetworkSession(SocketAddress remoteAddress, PacketProtocol protocol, NetworkServer server, Executor packetHandlerExecutor) {
-        super(remoteAddress, protocol, packetHandlerExecutor);
+    public ServerNetworkSession(SocketAddress remoteAddress, MinecraftProtocol protocol, NetworkServer server, Executor packetHandlerExecutor) {
+        super(remoteAddress, protocol, packetHandlerExecutor, PacketFlow.SERVERBOUND);
         this.server = server;
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
@@ -62,7 +62,7 @@ public class ClientListener extends SessionAdapter {
     @SneakyThrows
     @Override
     public void packetReceived(Session session, Packet packet) {
-        MinecraftProtocol protocol = (MinecraftProtocol) session.getPacketProtocol();
+        MinecraftProtocol protocol = session.getPacketProtocol();
         if (protocol.getInboundState() == ProtocolState.LOGIN) {
             if (packet instanceof ClientboundHelloPacket helloPacket) {
                 GameProfile profile = session.getFlag(MinecraftConstants.PROFILE_KEY);
@@ -97,9 +97,9 @@ public class ClientListener extends SessionAdapter {
                 session.send(new ServerboundKeyPacket(helloPacket.getPublicKey(), key, helloPacket.getChallenge()),
                     () -> session.setEncryption(protocol.createEncryption(key)));
             } else if (packet instanceof ClientboundLoginFinishedPacket) {
-                session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
+                session.switchInboundState(ProtocolState.CONFIGURATION);
                 session.send(new ServerboundLoginAcknowledgedPacket());
-                session.switchOutboundState(() -> protocol.setOutboundState(ProtocolState.CONFIGURATION));
+                session.switchOutboundState(ProtocolState.CONFIGURATION);
             } else if (packet instanceof ClientboundLoginDisconnectPacket loginDisconnectPacket) {
                 session.disconnect(loginDisconnectPacket.getReason());
             } else if (packet instanceof ClientboundLoginCompressionPacket loginCompressionPacket) {
@@ -132,9 +132,9 @@ public class ClientListener extends SessionAdapter {
             } else if (packet instanceof ClientboundDisconnectPacket disconnectPacket) {
                 session.disconnect(disconnectPacket.getReason());
             } else if (packet instanceof ClientboundStartConfigurationPacket) {
-                session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
+                session.switchInboundState(ProtocolState.CONFIGURATION);
                 session.send(new ServerboundConfigurationAcknowledgedPacket());
-                session.switchOutboundState(() -> protocol.setOutboundState(ProtocolState.CONFIGURATION));
+                session.switchOutboundState(ProtocolState.CONFIGURATION);
             } else if (packet instanceof ClientboundTransferPacket transferPacket) {
                 if (session.getFlag(MinecraftConstants.FOLLOW_TRANSFERS, true)) {
                     ClientNetworkSession newSession = new ClientNetworkSession(
@@ -154,16 +154,16 @@ public class ClientListener extends SessionAdapter {
             if (packet instanceof ClientboundKeepAlivePacket keepAlivePacket && session.getFlag(MinecraftConstants.AUTOMATIC_KEEP_ALIVE_MANAGEMENT, true)) {
                 session.send(new ServerboundKeepAlivePacket(keepAlivePacket.getPingId()));
             } else if (packet instanceof ClientboundFinishConfigurationPacket) {
-                session.switchInboundState(() -> protocol.setInboundState(ProtocolState.GAME));
+                session.switchInboundState(ProtocolState.GAME);
                 session.send(new ServerboundFinishConfigurationPacket());
-                session.switchOutboundState(() -> protocol.setOutboundState(ProtocolState.GAME));
+                session.switchOutboundState(ProtocolState.GAME);
             } else if (packet instanceof ClientboundSelectKnownPacks) {
                 if (session.getFlag(MinecraftConstants.SEND_BLANK_KNOWN_PACKS_RESPONSE, true)) {
                     session.send(new ServerboundSelectKnownPacks(Collections.emptyList()));
                 }
             } else if (packet instanceof ClientboundDisconnectPacket disconnectPacket) {
                 session.disconnect(disconnectPacket.getReason());
-            }else if (packet instanceof ClientboundTransferPacket transferPacket) {
+            } else if (packet instanceof ClientboundTransferPacket transferPacket) {
                 if (session.getFlag(MinecraftConstants.FOLLOW_TRANSFERS, true)) {
                     ClientNetworkSession newSession = new ClientNetworkSession(
                         InetSocketAddress.createUnresolved(transferPacket.getHost(), transferPacket.getPort()),
@@ -184,7 +184,7 @@ public class ClientListener extends SessionAdapter {
     @Override
     public void connected(ConnectedEvent event) {
         Session session = event.getSession();
-        MinecraftProtocol protocol = (MinecraftProtocol) session.getPacketProtocol();
+        MinecraftProtocol protocol = session.getPacketProtocol();
         ClientIntentionPacket intention = new ClientIntentionPacket(
             protocol.getCodec().getProtocolVersion(),
             session.getFlagSupplied(MinecraftConstants.CLIENT_HOST, () -> ((InetSocketAddress) session.getRemoteAddress()).getHostString()),
@@ -196,9 +196,9 @@ public class ClientListener extends SessionAdapter {
             case LOGIN, TRANSFER -> ProtocolState.LOGIN;
             case STATUS -> ProtocolState.STATUS;
         };
-        session.switchInboundState(() -> protocol.setInboundState(targetState));
+        session.switchInboundState(targetState);
         session.send(intention);
-        session.switchOutboundState(() -> protocol.setOutboundState(targetState));
+        session.switchOutboundState(targetState);
         switch (targetState) {
             case LOGIN -> {
                 GameProfile profile = session.getFlag(MinecraftConstants.PROFILE_KEY);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -97,7 +97,7 @@ public class ServerListener extends SessionAdapter {
             if (packet instanceof ClientIntentionPacket intentionPacket) {
                 switch (intentionPacket.getIntent()) {
                     case STATUS -> {
-                        protocol.setOutboundState(ProtocolState.STATUS);
+                        session.switchOutboundState(ProtocolState.STATUS);
                         session.switchInboundState(ProtocolState.STATUS);
                     }
                     case TRANSFER -> beginLogin(session, protocol, intentionPacket, true);
@@ -125,7 +125,7 @@ public class ServerListener extends SessionAdapter {
                 session.setEncryption(protocol.createEncryption(key));
                 new Thread(() -> authenticate(session, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true), key)).start();
             } else if (packet instanceof ServerboundLoginAcknowledgedPacket) {
-                protocol.setOutboundState(ProtocolState.CONFIGURATION);
+                session.switchOutboundState(ProtocolState.CONFIGURATION);
                 session.switchInboundState(ProtocolState.CONFIGURATION);
                 keepAliveState = new KeepAliveState();
                 if (session.getFlag(MinecraftConstants.AUTOMATIC_KEEP_ALIVE_MANAGEMENT, true)) {
@@ -188,7 +188,7 @@ public class ServerListener extends SessionAdapter {
             if (packet instanceof ServerboundKeepAlivePacket keepAlivePacket) {
                 handleKeepAlive(session, keepAlivePacket);
             } else if (packet instanceof ServerboundFinishConfigurationPacket) {
-                protocol.setOutboundState(ProtocolState.GAME);
+                session.switchOutboundState(ProtocolState.GAME);
                 session.switchInboundState(ProtocolState.GAME);
                 keepAliveState = new KeepAliveState();
                 ServerLoginHandler handler = session.getFlag(MinecraftConstants.SERVER_LOGIN_HANDLER_KEY);
@@ -213,7 +213,7 @@ public class ServerListener extends SessionAdapter {
 
     private void beginLogin(Session session, MinecraftProtocol protocol, ClientIntentionPacket packet, boolean transferred) {
         isTransfer = transferred;
-        protocol.setOutboundState(ProtocolState.LOGIN);
+        session.switchOutboundState(ProtocolState.LOGIN);
         if (transferred && !session.getFlag(MinecraftConstants.ACCEPT_TRANSFERS_KEY)) {
             session.disconnect(Component.translatable("multiplayer.disconnect.transfers_disabled"));
         } else if (packet.getProtocolVersion() > protocol.getCodec().getProtocolVersion()) {

--- a/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocolTest.java
+++ b/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/MinecraftProtocolTest.java
@@ -143,7 +143,7 @@ public class MinecraftProtocolTest {
     private static class DisconnectListener extends SessionAdapter {
         @Override
         public void disconnected(DisconnectedEvent event) {
-            log.error("Disconnected: {}", event.getReason(), event.getCause());
+            log.error("Disconnected: {}", event.getDetails().reason(), event.getDetails().cause());
         }
     }
 }


### PR DESCRIPTION
This code changes a few things around the codebase:
- DisconnectionDetails were introduced and allow more extension in the future. Those can be used in the future to attach even more info to disconnects. (Like Minecraft does)
- PacketFlow was introduced to handle server disconnect packets inside NetworkSession
- NetworkSession and children now only accept MinecraftProtocol which removes unnecessary casts across the codebase and makes it easier to do Minecraft-related changes specifically. The library slowly moves away from accepting non-minecraft serlization for network sessions.
- Disconnect method behaviour was changed to match Minecraft, may affect events, but tests still pass and disconnects still get handled properly with events.
- Errors in packet sending are now fired on the event loop to ensure processing.
- Server packet disconnect handling was moved to NetworkSession, just like Minecrafts Connection class
- Add/remove checks to match Minecrafts behaviour
- isConnected now no longer considers being disconnected to match Minecrafts behaviour (tests still pass)
- Some small syntax cleanups where code was unnecessary.