### PR TITLE
Split up MetadataType into MetadataTypes & DataComponents too

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
@@ -56,6 +56,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.entity.player.PlayerSpawnIn
 import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponent;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentType;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponentTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.DataComponents;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.HolderSet;
 import org.geysermc.mcprotocollib.protocol.data.game.level.LightUpdateData;
@@ -449,13 +450,13 @@ public class MinecraftTypes {
 
         Map<DataComponentType<?>, DataComponent<?, ?>> dataComponents = new HashMap<>();
         for (int k = 0; k < nonNullComponents; k++) {
-            DataComponentType<?> dataComponentType = DataComponentType.from(MinecraftTypes.readVarInt(buf));
+            DataComponentType<?> dataComponentType = DataComponentTypes.from(MinecraftTypes.readVarInt(buf));
             DataComponent<?, ?> dataComponent = dataComponentType.readDataComponent(buf);
             dataComponents.put(dataComponentType, dataComponent);
         }
 
         for (int k = 0; k < nullComponents; k++) {
-            DataComponentType<?> dataComponentType = DataComponentType.from(MinecraftTypes.readVarInt(buf));
+            DataComponentType<?> dataComponentType = DataComponentTypes.from(MinecraftTypes.readVarInt(buf));
             DataComponent<?, ?> dataComponent = dataComponentType.readNullDataComponent();
             dataComponents.put(dataComponentType, dataComponent);
         }
@@ -504,7 +505,7 @@ public class MinecraftTypes {
 
         Map<DataComponentType<?>, DataComponent<?, ?>> dataComponents = new HashMap<>();
         for (int i = 0; i < componentsLength; i++) {
-            DataComponentType<?> dataComponentType = DataComponentType.from(MinecraftTypes.readVarInt(buf));
+            DataComponentType<?> dataComponentType = DataComponentTypes.from(MinecraftTypes.readVarInt(buf));
             DataComponent<?, ?> dataComponent = dataComponentType.readDataComponent(buf);
             dataComponents.put(dataComponentType, dataComponent);
         }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
@@ -43,6 +43,7 @@ import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.ArmadilloSt
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.GlobalPos;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.MetadataType;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.MetadataTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.PaintingVariant;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.Pose;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.SnifferState;
@@ -714,11 +715,11 @@ public class MinecraftTypes {
 
     public static MetadataType<?> readMetadataType(ByteBuf buf) {
         int id = MinecraftTypes.readVarInt(buf);
-        if (id >= MetadataType.size()) {
-            throw new IllegalArgumentException("Received id " + id + " for MetadataType when the maximum was " + MetadataType.size() + "!");
+        if (id >= MetadataTypes.size()) {
+            throw new IllegalArgumentException("Received id " + id + " for MetadataType when the maximum was " + MetadataTypes.size() + "!");
         }
 
-        return MetadataType.from(id);
+        return MetadataTypes.from(id);
     }
 
     public static void writeMetadataType(ByteBuf buf, MetadataType<?> type) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/BooleanMetadataType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/BooleanMetadataType.java
@@ -8,8 +8,8 @@ public class BooleanMetadataType extends MetadataType<Boolean> {
     private final BooleanWriter primitiveWriter;
     private final BooleanEntityMetadataFactory primitiveFactory;
 
-    protected BooleanMetadataType(BooleanReader reader, BooleanWriter writer, BooleanEntityMetadataFactory metadataFactory) {
-        super(reader, writer, metadataFactory);
+    protected BooleanMetadataType(int id, BooleanReader reader, BooleanWriter writer, BooleanEntityMetadataFactory metadataFactory) {
+        super(id, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;
         this.primitiveWriter = writer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/ByteMetadataType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/ByteMetadataType.java
@@ -8,8 +8,8 @@ public class ByteMetadataType extends MetadataType<Byte> {
     private final ByteWriter primitiveWriter;
     private final ByteEntityMetadataFactory primitiveFactory;
 
-    protected ByteMetadataType(ByteReader reader, ByteWriter writer, ByteEntityMetadataFactory metadataFactory) {
-        super(reader, writer, metadataFactory);
+    protected ByteMetadataType(int id, ByteReader reader, ByteWriter writer, ByteEntityMetadataFactory metadataFactory) {
+        super(id, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;
         this.primitiveWriter = writer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/FloatMetadataType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/FloatMetadataType.java
@@ -8,8 +8,8 @@ public class FloatMetadataType extends MetadataType<Float> {
     private final FloatWriter primitiveWriter;
     private final FloatEntityMetadataFactory primitiveFactory;
 
-    protected FloatMetadataType(FloatReader reader, FloatWriter writer, FloatEntityMetadataFactory metadataFactory) {
-        super(reader, writer, metadataFactory);
+    protected FloatMetadataType(int id, FloatReader reader, FloatWriter writer, FloatEntityMetadataFactory metadataFactory) {
+        super(id, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;
         this.primitiveWriter = writer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/IntMetadataType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/IntMetadataType.java
@@ -8,8 +8,8 @@ public class IntMetadataType extends MetadataType<Integer> {
     private final IntWriter primitiveWriter;
     private final IntEntityMetadataFactory primitiveFactory;
 
-    protected IntMetadataType(IntReader reader, IntWriter writer, IntEntityMetadataFactory metadataFactory) {
-        super(reader, writer, metadataFactory);
+    protected IntMetadataType(int id, IntReader reader, IntWriter writer, IntEntityMetadataFactory metadataFactory) {
+        super(id, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;
         this.primitiveWriter = writer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/LongMetadataType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/LongMetadataType.java
@@ -8,8 +8,8 @@ public class LongMetadataType extends MetadataType<Long> {
     private final LongWriter primitiveWriter;
     private final LongEntityMetadataFactory primitiveFactory;
 
-    protected LongMetadataType(LongReader reader, LongWriter writer, LongEntityMetadataFactory metadataFactory) {
-        super(reader, writer, metadataFactory);
+    protected LongMetadataType(int id, LongReader reader, LongWriter writer, LongEntityMetadataFactory metadataFactory) {
+        super(id, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;
         this.primitiveWriter = writer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/MetadataType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/MetadataType.java
@@ -36,12 +36,12 @@ public class MetadataType<T> {
     }
 
     @FunctionalInterface
-    public interface BasicReader<V> extends MetadataType.Reader<V> {
+    public interface BasicReader<V> extends Reader<V> {
         V read(ByteBuf input);
     }
 
     @FunctionalInterface
-    public interface BasicWriter<V> extends MetadataType.Writer<V> {
+    public interface BasicWriter<V> extends Writer<V> {
         void write(ByteBuf output, V value);
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/MetadataType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/MetadataType.java
@@ -2,76 +2,19 @@ package org.geysermc.mcprotocollib.protocol.data.game.entity.metadata;
 
 import io.netty.buffer.ByteBuf;
 import lombok.Getter;
-import net.kyori.adventure.text.Component;
-import org.cloudburstmc.math.vector.Vector3f;
-import org.cloudburstmc.math.vector.Vector3i;
-import org.cloudburstmc.math.vector.Vector4f;
-import org.cloudburstmc.nbt.NbtMap;
-import org.geysermc.mcprotocollib.protocol.codec.MinecraftTypes;
-import org.geysermc.mcprotocollib.protocol.data.game.Holder;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.BooleanEntityMetadata;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.ByteEntityMetadata;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.FloatEntityMetadata;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.IntEntityMetadata;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.LongEntityMetadata;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.ObjectEntityMetadata;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.object.Direction;
-import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
-import org.geysermc.mcprotocollib.protocol.data.game.level.particle.Particle;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 @Getter
 public class MetadataType<T> {
-    private static final List<MetadataType<?>> VALUES = new ArrayList<>();
-
-    public static final ByteMetadataType BYTE = new ByteMetadataType(ByteBuf::readByte, ByteBuf::writeByte, ByteEntityMetadata::new);
-    public static final IntMetadataType INT = new IntMetadataType(MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new);
-    public static final LongMetadataType LONG = new LongMetadataType(MinecraftTypes::readVarLong, MinecraftTypes::writeVarLong, LongEntityMetadata::new);
-    public static final FloatMetadataType FLOAT = new FloatMetadataType(ByteBuf::readFloat, ByteBuf::writeFloat, FloatEntityMetadata::new);
-    public static final MetadataType<String> STRING = new MetadataType<>(MinecraftTypes::readString, MinecraftTypes::writeString, ObjectEntityMetadata::new);
-    public static final MetadataType<Component> CHAT = new MetadataType<>(MinecraftTypes::readComponent, MinecraftTypes::writeComponent, ObjectEntityMetadata::new);
-    public static final MetadataType<Optional<Component>> OPTIONAL_CHAT = new MetadataType<>(optionalReader(MinecraftTypes::readComponent), optionalWriter(MinecraftTypes::writeComponent), ObjectEntityMetadata::new);
-    public static final MetadataType<ItemStack> ITEM = new MetadataType<>(MinecraftTypes::readOptionalItemStack, MinecraftTypes::writeOptionalItemStack, ObjectEntityMetadata::new);
-    public static final BooleanMetadataType BOOLEAN = new BooleanMetadataType(ByteBuf::readBoolean, ByteBuf::writeBoolean, BooleanEntityMetadata::new);
-    public static final MetadataType<Vector3f> ROTATION = new MetadataType<>(MinecraftTypes::readRotation, MinecraftTypes::writeRotation, ObjectEntityMetadata::new);
-    public static final MetadataType<Vector3i> POSITION = new MetadataType<>(MinecraftTypes::readPosition, MinecraftTypes::writePosition, ObjectEntityMetadata::new);
-    public static final MetadataType<Optional<Vector3i>> OPTIONAL_POSITION = new MetadataType<>(optionalReader(MinecraftTypes::readPosition), optionalWriter(MinecraftTypes::writePosition), ObjectEntityMetadata::new);
-    public static final MetadataType<Direction> DIRECTION = new MetadataType<>(MinecraftTypes::readDirection, MinecraftTypes::writeDirection, ObjectEntityMetadata::new);
-    public static final MetadataType<Optional<UUID>> OPTIONAL_UUID = new MetadataType<>(optionalReader(MinecraftTypes::readUUID), optionalWriter(MinecraftTypes::writeUUID), ObjectEntityMetadata::new);
-    public static final IntMetadataType BLOCK_STATE = new IntMetadataType(MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new);
-    public static final IntMetadataType OPTIONAL_BLOCK_STATE = new IntMetadataType(MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new);
-    public static final MetadataType<NbtMap> NBT_TAG = new MetadataType<>(MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectEntityMetadata::new);
-    public static final MetadataType<Particle> PARTICLE = new MetadataType<>(MinecraftTypes::readParticle, MinecraftTypes::writeParticle, ObjectEntityMetadata::new);
-    public static final MetadataType<List<Particle>> PARTICLES = new MetadataType<>(listReader(MinecraftTypes::readParticle), listWriter(MinecraftTypes::writeParticle), ObjectEntityMetadata::new);
-    public static final MetadataType<VillagerData> VILLAGER_DATA = new MetadataType<>(MinecraftTypes::readVillagerData, MinecraftTypes::writeVillagerData, ObjectEntityMetadata::new);
-    public static final OptionalIntMetadataType OPTIONAL_VARINT = new OptionalIntMetadataType(ObjectEntityMetadata::new);
-    public static final MetadataType<Pose> POSE = new MetadataType<>(MinecraftTypes::readPose, MinecraftTypes::writePose, ObjectEntityMetadata::new);
-    public static final IntMetadataType CAT_VARIANT = new IntMetadataType(MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new);
-    public static final MetadataType<Holder<WolfVariant>> WOLF_VARIANT = new MetadataType<>(MinecraftTypes::readWolfVariant, MinecraftTypes::writeWolfVariant, ObjectEntityMetadata::new);
-    public static final IntMetadataType FROG_VARIANT = new IntMetadataType(MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new);
-    public static final MetadataType<Optional<GlobalPos>> OPTIONAL_GLOBAL_POS = new MetadataType<>(optionalReader(MinecraftTypes::readGlobalPos), optionalWriter(MinecraftTypes::writeGlobalPos), ObjectEntityMetadata::new);
-    public static final MetadataType<Holder<PaintingVariant>> PAINTING_VARIANT = new MetadataType<>(MinecraftTypes::readPaintingVariant, MinecraftTypes::writePaintingVariant, ObjectEntityMetadata::new);
-    public static final MetadataType<SnifferState> SNIFFER_STATE = new MetadataType<>(MinecraftTypes::readSnifferState, MinecraftTypes::writeSnifferState, ObjectEntityMetadata::new);
-    public static final MetadataType<ArmadilloState> ARMADILLO_STATE = new MetadataType<>(MinecraftTypes::readArmadilloState, MinecraftTypes::writeArmadilloState, ObjectEntityMetadata::new);
-    public static final MetadataType<Vector3f> VECTOR3 = new MetadataType<>(MinecraftTypes::readRotation, MinecraftTypes::writeRotation, ObjectEntityMetadata::new);
-    public static final MetadataType<Vector4f> QUATERNION = new MetadataType<>(MinecraftTypes::readQuaternion, MinecraftTypes::writeQuaternion, ObjectEntityMetadata::new);
-
     protected final int id;
     protected final Reader<T> reader;
     protected final Writer<T> writer;
     protected final EntityMetadataFactory<T> metadataFactory;
 
-    protected MetadataType(Reader<T> reader, Writer<T> writer, EntityMetadataFactory<T> metadataFactory) {
-        this.id = VALUES.size();
+    protected MetadataType(int id, Reader<T> reader, Writer<T> writer, EntityMetadataFactory<T> metadataFactory) {
+        this.id = id;
         this.reader = reader;
         this.writer = writer;
         this.metadataFactory = metadataFactory;
-
-        VALUES.add(this);
     }
 
     public EntityMetadata<T, ? extends MetadataType<T>> readMetadata(ByteBuf input, int id) {
@@ -93,89 +36,17 @@ public class MetadataType<T> {
     }
 
     @FunctionalInterface
-    public interface BasicReader<V> extends Reader<V> {
+    public interface BasicReader<V> extends MetadataType.Reader<V> {
         V read(ByteBuf input);
     }
 
     @FunctionalInterface
-    public interface BasicWriter<V> extends Writer<V> {
+    public interface BasicWriter<V> extends MetadataType.Writer<V> {
         void write(ByteBuf output, V value);
     }
 
     @FunctionalInterface
     public interface EntityMetadataFactory<V> {
         EntityMetadata<V, ? extends MetadataType<V>> create(int id, MetadataType<V> type, V value);
-    }
-
-    private static <T> BasicReader<Optional<T>> optionalReader(BasicReader<T> reader) {
-        return input -> {
-            if (!input.readBoolean()) {
-                return Optional.empty();
-            }
-
-            return Optional.of(reader.read(input));
-        };
-    }
-
-    private static <T> Reader<Optional<T>> optionalReader(Reader<T> reader) {
-        return (input) -> {
-            if (!input.readBoolean()) {
-                return Optional.empty();
-            }
-
-            return Optional.of(reader.read(input));
-        };
-    }
-
-    private static <T> BasicWriter<Optional<T>> optionalWriter(BasicWriter<T> writer) {
-        return (output, value) -> {
-            output.writeBoolean(value.isPresent());
-            value.ifPresent(t -> writer.write(output, t));
-        };
-    }
-
-    private static <T> Writer<Optional<T>> optionalWriter(Writer<T> writer) {
-        return (output, value) -> {
-            output.writeBoolean(value.isPresent());
-            value.ifPresent(t -> writer.write(output, t));
-        };
-    }
-
-    private static <T> Reader<List<T>> listReader(Reader<T> reader) {
-        return (input) -> {
-            List<T> ret = new ArrayList<>();
-            int size = MinecraftTypes.readVarInt(input);
-            for (int i = 0; i < size; i++) {
-                ret.add(reader.read(input));
-            }
-
-            return ret;
-        };
-    }
-
-    private static <T> Writer<List<T>> listWriter(Writer<T> writer) {
-        return (output, value) -> {
-            MinecraftTypes.writeVarInt(output, value.size());
-            for (T object : value) {
-                writer.write(output, object);
-            }
-        };
-    }
-
-    public static MetadataType<?> read(ByteBuf in) {
-        int id = MinecraftTypes.readVarInt(in);
-        if (id >= VALUES.size()) {
-            throw new IllegalArgumentException("Received id " + id + " for MetadataType when the maximum was " + VALUES.size() + "!");
-        }
-
-        return VALUES.get(id);
-    }
-
-    public static MetadataType<?> from(int id) {
-        return VALUES.get(id);
-    }
-
-    public static int size() {
-        return VALUES.size();
     }
 }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/MetadataTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/MetadataTypes.java
@@ -1,0 +1,141 @@
+package org.geysermc.mcprotocollib.protocol.data.game.entity.metadata;
+
+import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+import lombok.Getter;
+import net.kyori.adventure.text.Component;
+import org.cloudburstmc.math.vector.Vector3f;
+import org.cloudburstmc.math.vector.Vector3i;
+import org.cloudburstmc.math.vector.Vector4f;
+import org.cloudburstmc.nbt.NbtMap;
+import org.geysermc.mcprotocollib.protocol.codec.MinecraftTypes;
+import org.geysermc.mcprotocollib.protocol.data.game.Holder;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.BooleanEntityMetadata;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.ByteEntityMetadata;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.FloatEntityMetadata;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.IntEntityMetadata;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.LongEntityMetadata;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.ObjectEntityMetadata;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.object.Direction;
+import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
+import org.geysermc.mcprotocollib.protocol.data.game.level.particle.Particle;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Getter
+public class MetadataTypes<T> {
+    private static final List<MetadataType<?>> VALUES = new ArrayList<>();
+
+    public static final ByteMetadataType BYTE = register(id -> new ByteMetadataType(id, ByteBuf::readByte, ByteBuf::writeByte, ByteEntityMetadata::new));
+    public static final IntMetadataType INT = register(id -> new IntMetadataType(id, MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new));
+    public static final LongMetadataType LONG = register(id -> new LongMetadataType(id, MinecraftTypes::readVarLong, MinecraftTypes::writeVarLong, LongEntityMetadata::new));
+    public static final FloatMetadataType FLOAT = register(id -> new FloatMetadataType(id, ByteBuf::readFloat, ByteBuf::writeFloat, FloatEntityMetadata::new));
+    public static final MetadataType<String> STRING = register(id -> new MetadataType<>(id, MinecraftTypes::readString, MinecraftTypes::writeString, ObjectEntityMetadata::new));
+    public static final MetadataType<Component> CHAT = register(id -> new MetadataType<>(id, MinecraftTypes::readComponent, MinecraftTypes::writeComponent, ObjectEntityMetadata::new));
+    public static final MetadataType<Optional<Component>> OPTIONAL_CHAT = register(id -> new MetadataType<>(id, optionalReader(MinecraftTypes::readComponent), optionalWriter(MinecraftTypes::writeComponent), ObjectEntityMetadata::new));
+    public static final MetadataType<ItemStack> ITEM = register(id -> new MetadataType<>(id, MinecraftTypes::readOptionalItemStack, MinecraftTypes::writeOptionalItemStack, ObjectEntityMetadata::new));
+    public static final BooleanMetadataType BOOLEAN = register(id -> new BooleanMetadataType(id, ByteBuf::readBoolean, ByteBuf::writeBoolean, BooleanEntityMetadata::new));
+    public static final MetadataType<Vector3f> ROTATION = register(id -> new MetadataType<>(id, MinecraftTypes::readRotation, MinecraftTypes::writeRotation, ObjectEntityMetadata::new));
+    public static final MetadataType<Vector3i> POSITION = register(id -> new MetadataType<>(id, MinecraftTypes::readPosition, MinecraftTypes::writePosition, ObjectEntityMetadata::new));
+    public static final MetadataType<Optional<Vector3i>> OPTIONAL_POSITION = register(id -> new MetadataType<>(id, optionalReader(MinecraftTypes::readPosition), optionalWriter(MinecraftTypes::writePosition), ObjectEntityMetadata::new));
+    public static final MetadataType<Direction> DIRECTION = register(id -> new MetadataType<>(id, MinecraftTypes::readDirection, MinecraftTypes::writeDirection, ObjectEntityMetadata::new));
+    public static final MetadataType<Optional<UUID>> OPTIONAL_UUID = register(id -> new MetadataType<>(id, optionalReader(MinecraftTypes::readUUID), optionalWriter(MinecraftTypes::writeUUID), ObjectEntityMetadata::new));
+    public static final IntMetadataType BLOCK_STATE = register(id -> new IntMetadataType(id, MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new));
+    public static final IntMetadataType OPTIONAL_BLOCK_STATE = register(id -> new IntMetadataType(id, MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new));
+    public static final MetadataType<NbtMap> NBT_TAG = register(id -> new MetadataType<>(id, MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectEntityMetadata::new));
+    public static final MetadataType<Particle> PARTICLE = register(id -> new MetadataType<>(id, MinecraftTypes::readParticle, MinecraftTypes::writeParticle, ObjectEntityMetadata::new));
+    public static final MetadataType<List<Particle>> PARTICLES = register(id -> new MetadataType<>(id, listReader(MinecraftTypes::readParticle), listWriter(MinecraftTypes::writeParticle), ObjectEntityMetadata::new));
+    public static final MetadataType<VillagerData> VILLAGER_DATA = register(id -> new MetadataType<>(id, MinecraftTypes::readVillagerData, MinecraftTypes::writeVillagerData, ObjectEntityMetadata::new));
+    public static final OptionalIntMetadataType OPTIONAL_VARINT = register(id -> new OptionalIntMetadataType(id, ObjectEntityMetadata::new));
+    public static final MetadataType<Pose> POSE = register(id -> new MetadataType<>(id, MinecraftTypes::readPose, MinecraftTypes::writePose, ObjectEntityMetadata::new));
+    public static final IntMetadataType CAT_VARIANT = register(id -> new IntMetadataType(id, MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new));
+    public static final MetadataType<Holder<WolfVariant>> WOLF_VARIANT = register(id -> new MetadataType<>(id, MinecraftTypes::readWolfVariant, MinecraftTypes::writeWolfVariant, ObjectEntityMetadata::new));
+    public static final IntMetadataType FROG_VARIANT = register(id -> new IntMetadataType(id, MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntEntityMetadata::new));
+    public static final MetadataType<Optional<GlobalPos>> OPTIONAL_GLOBAL_POS = register(id -> new MetadataType<>(id, optionalReader(MinecraftTypes::readGlobalPos), optionalWriter(MinecraftTypes::writeGlobalPos), ObjectEntityMetadata::new));
+    public static final MetadataType<Holder<PaintingVariant>> PAINTING_VARIANT = register(id -> new MetadataType<>(id, MinecraftTypes::readPaintingVariant, MinecraftTypes::writePaintingVariant, ObjectEntityMetadata::new));
+    public static final MetadataType<SnifferState> SNIFFER_STATE = register(id -> new MetadataType<>(id, MinecraftTypes::readSnifferState, MinecraftTypes::writeSnifferState, ObjectEntityMetadata::new));
+    public static final MetadataType<ArmadilloState> ARMADILLO_STATE = register(id -> new MetadataType<>(id, MinecraftTypes::readArmadilloState, MinecraftTypes::writeArmadilloState, ObjectEntityMetadata::new));
+    public static final MetadataType<Vector3f> VECTOR3 = register(id -> new MetadataType<>(id, MinecraftTypes::readRotation, MinecraftTypes::writeRotation, ObjectEntityMetadata::new));
+    public static final MetadataType<Vector4f> QUATERNION =register(id ->  new MetadataType<>(id, MinecraftTypes::readQuaternion, MinecraftTypes::writeQuaternion, ObjectEntityMetadata::new));
+
+    public static <T extends MetadataType<?>> T register(Int2ObjectFunction<T> factory) {
+        T value = factory.apply(VALUES.size());
+        VALUES.add(value);
+        return value;
+    }
+
+    private static <T> MetadataType.BasicReader<Optional<T>> optionalReader(MetadataType.BasicReader<T> reader) {
+        return input -> {
+            if (!input.readBoolean()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(reader.read(input));
+        };
+    }
+
+    private static <T> MetadataType.Reader<Optional<T>> optionalReader(MetadataType.Reader<T> reader) {
+        return (input) -> {
+            if (!input.readBoolean()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(reader.read(input));
+        };
+    }
+
+    private static <T> MetadataType.BasicWriter<Optional<T>> optionalWriter(MetadataType.BasicWriter<T> writer) {
+        return (output, value) -> {
+            output.writeBoolean(value.isPresent());
+            value.ifPresent(t -> writer.write(output, t));
+        };
+    }
+
+    private static <T> MetadataType.Writer<Optional<T>> optionalWriter(MetadataType.Writer<T> writer) {
+        return (output, value) -> {
+            output.writeBoolean(value.isPresent());
+            value.ifPresent(t -> writer.write(output, t));
+        };
+    }
+
+    private static <T> MetadataType.Reader<List<T>> listReader(MetadataType.Reader<T> reader) {
+        return (input) -> {
+            List<T> ret = new ArrayList<>();
+            int size = MinecraftTypes.readVarInt(input);
+            for (int i = 0; i < size; i++) {
+                ret.add(reader.read(input));
+            }
+
+            return ret;
+        };
+    }
+
+    private static <T> MetadataType.Writer<List<T>> listWriter(MetadataType.Writer<T> writer) {
+        return (output, value) -> {
+            MinecraftTypes.writeVarInt(output, value.size());
+            for (T object : value) {
+                writer.write(output, object);
+            }
+        };
+    }
+
+    public static MetadataType<?> read(ByteBuf in) {
+        int id = MinecraftTypes.readVarInt(in);
+        if (id >= VALUES.size()) {
+            throw new IllegalArgumentException("Received id " + id + " for MetadataType when the maximum was " + VALUES.size() + "!");
+        }
+
+        return VALUES.get(id);
+    }
+
+    public static MetadataType<?> from(int id) {
+        return VALUES.get(id);
+    }
+
+    public static int size() {
+        return VALUES.size();
+    }
+}

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/OptionalIntMetadataType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/OptionalIntMetadataType.java
@@ -6,8 +6,8 @@ import org.geysermc.mcprotocollib.protocol.codec.MinecraftTypes;
 import java.util.OptionalInt;
 
 public class OptionalIntMetadataType extends MetadataType<OptionalInt> {
-    protected OptionalIntMetadataType(EntityMetadataFactory<OptionalInt> metadataFactory) {
-        super(OptionalIntReader.INSTANCE, OptionalIntWriter.INSTANCE, metadataFactory);
+    protected OptionalIntMetadataType(int id, EntityMetadataFactory<OptionalInt> metadataFactory) {
+        super(id, OptionalIntReader.INSTANCE, OptionalIntWriter.INSTANCE, metadataFactory);
     }
 
     public static class OptionalIntReader implements Reader<OptionalInt> {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/BooleanComponentType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/BooleanComponentType.java
@@ -9,8 +9,8 @@ public class BooleanComponentType extends DataComponentType<Boolean> {
     protected final BooleanWriter primitiveWriter;
     protected final BooleanDataComponentFactory primitiveFactory;
 
-    protected BooleanComponentType(@KeyPattern String key, BooleanReader reader, BooleanWriter writer, BooleanDataComponentFactory metadataFactory) {
-        super(key, reader, writer, metadataFactory);
+    protected BooleanComponentType(int id, @KeyPattern String key, BooleanReader reader, BooleanWriter writer, BooleanDataComponentFactory metadataFactory) {
+        super(id, key, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;
         this.primitiveWriter = writer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/BooleanComponentType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/BooleanComponentType.java
@@ -1,6 +1,7 @@
 package org.geysermc.mcprotocollib.protocol.data.game.item.component;
 
 import io.netty.buffer.ByteBuf;
+import net.kyori.adventure.key.KeyPattern;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.type.BooleanDataComponent;
 
 public class BooleanComponentType extends DataComponentType<Boolean> {
@@ -8,7 +9,7 @@ public class BooleanComponentType extends DataComponentType<Boolean> {
     protected final BooleanWriter primitiveWriter;
     protected final BooleanDataComponentFactory primitiveFactory;
 
-    protected BooleanComponentType(String key, BooleanReader reader, BooleanWriter writer, BooleanDataComponentFactory metadataFactory) {
+    protected BooleanComponentType(@KeyPattern String key, BooleanReader reader, BooleanWriter writer, BooleanDataComponentFactory metadataFactory) {
         super(key, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentType.java
@@ -3,6 +3,7 @@ package org.geysermc.mcprotocollib.protocol.data.game.item.component;
 import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import net.kyori.adventure.key.Key;
+import net.kyori.adventure.key.KeyPattern;
 import net.kyori.adventure.text.Component;
 import org.cloudburstmc.nbt.NbtList;
 import org.cloudburstmc.nbt.NbtMap;
@@ -95,9 +96,8 @@ public class DataComponentType<T> {
     protected final Writer<T> writer;
     protected final DataComponentFactory<T> dataComponentFactory;
 
-    protected DataComponentType(String key, Reader<T> reader, Writer<T> writer, DataComponentFactory<T> dataComponentFactory) {
+    protected DataComponentType(@KeyPattern String key, Reader<T> reader, Writer<T> writer, DataComponentFactory<T> dataComponentFactory) {
         this.id = VALUES.size();
-        //noinspection PatternValidation
         this.key = Key.key(key);
         this.reader = reader;
         this.writer = writer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentType.java
@@ -4,106 +4,21 @@ import io.netty.buffer.ByteBuf;
 import lombok.Getter;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.KeyPattern;
-import net.kyori.adventure.text.Component;
-import org.cloudburstmc.nbt.NbtList;
-import org.cloudburstmc.nbt.NbtMap;
-import org.geysermc.mcprotocollib.auth.GameProfile;
-import org.geysermc.mcprotocollib.protocol.codec.MinecraftTypes;
-import org.geysermc.mcprotocollib.protocol.data.game.Holder;
-import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.type.BooleanDataComponent;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.type.IntDataComponent;
-import org.geysermc.mcprotocollib.protocol.data.game.item.component.type.ObjectDataComponent;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 public class DataComponentType<T> {
-    private static final List<DataComponentType<?>> VALUES = new ArrayList<>();
-
-    public static final DataComponentType<NbtMap> CUSTOM_DATA = new DataComponentType<>("custom_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-    public static final IntComponentType MAX_STACK_SIZE = new IntComponentType("max_stack_size", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final IntComponentType MAX_DAMAGE = new IntComponentType("max_damage", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final IntComponentType DAMAGE = new IntComponentType("damage", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final DataComponentType<Unbreakable> UNBREAKABLE = new DataComponentType<>("unbreakable", ItemTypes::readUnbreakable, ItemTypes::writeUnbreakable, ObjectDataComponent::new);
-    public static final DataComponentType<Component> CUSTOM_NAME = new DataComponentType<>("custom_name", MinecraftTypes::readComponent, MinecraftTypes::writeComponent, ObjectDataComponent::new);
-    public static final DataComponentType<Component> ITEM_NAME = new DataComponentType<>("item_name", MinecraftTypes::readComponent, MinecraftTypes::writeComponent, ObjectDataComponent::new);
-    public static final DataComponentType<Key> ITEM_MODEL = new DataComponentType<>("item_model", MinecraftTypes::readResourceLocation, MinecraftTypes::writeResourceLocation, ObjectDataComponent::new);
-    public static final DataComponentType<List<Component>> LORE = new DataComponentType<>("lore", listReader(MinecraftTypes::readComponent), listWriter(MinecraftTypes::writeComponent), ObjectDataComponent::new);
-    public static final IntComponentType RARITY = new IntComponentType("rarity", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final DataComponentType<ItemEnchantments> ENCHANTMENTS = new DataComponentType<>("enchantments", ItemTypes::readItemEnchantments, ItemTypes::writeItemEnchantments, ObjectDataComponent::new);
-    public static final DataComponentType<AdventureModePredicate> CAN_PLACE_ON = new DataComponentType<>("can_place_on", ItemTypes::readAdventureModePredicate, ItemTypes::writeAdventureModePredicate, ObjectDataComponent::new);
-    public static final DataComponentType<AdventureModePredicate> CAN_BREAK = new DataComponentType<>("can_break", ItemTypes::readAdventureModePredicate, ItemTypes::writeAdventureModePredicate, ObjectDataComponent::new);
-    public static final DataComponentType<ItemAttributeModifiers> ATTRIBUTE_MODIFIERS = new DataComponentType<>("attribute_modifiers", ItemTypes::readItemAttributeModifiers, ItemTypes::writeItemAttributeModifiers, ObjectDataComponent::new);
-    public static final DataComponentType<CustomModelData> CUSTOM_MODEL_DATA = new DataComponentType<>("custom_model_data", ItemTypes::readCustomModelData, ItemTypes::writeCustomModelData, ObjectDataComponent::new);
-    public static final DataComponentType<Unit> HIDE_ADDITIONAL_TOOLTIP = new DataComponentType<>("hide_additional_tooltip", unitReader(), unitWriter(), ObjectDataComponent::new);
-    public static final DataComponentType<Unit> HIDE_TOOLTIP = new DataComponentType<>("hide_tooltip", unitReader(), unitWriter(), ObjectDataComponent::new);
-    public static final IntComponentType REPAIR_COST = new IntComponentType("repair_cost", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final DataComponentType<Unit> CREATIVE_SLOT_LOCK = new DataComponentType<>("creative_slot_lock", unitReader(), unitWriter(), ObjectDataComponent::new);
-    public static final BooleanComponentType ENCHANTMENT_GLINT_OVERRIDE = new BooleanComponentType("enchantment_glint_override", ByteBuf::readBoolean, ByteBuf::writeBoolean, BooleanDataComponent::new);
-    public static final DataComponentType<NbtMap> INTANGIBLE_PROJECTILE = new DataComponentType<>("intangible_projectile", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-    public static final DataComponentType<FoodProperties> FOOD = new DataComponentType<>("food", ItemTypes::readFoodProperties, ItemTypes::writeFoodProperties, ObjectDataComponent::new);
-    public static final DataComponentType<Consumable> CONSUMABLE = new DataComponentType<>("consumable", ItemTypes::readConsumable, ItemTypes::writeConsumable, ObjectDataComponent::new);
-    public static final DataComponentType<ItemStack> USE_REMAINDER = new DataComponentType<>("use_remainder", MinecraftTypes::readItemStack, MinecraftTypes::writeItemStack, ObjectDataComponent::new);
-    public static final DataComponentType<UseCooldown> USE_COOLDOWN = new DataComponentType<>("use_cooldown", ItemTypes::readUseCooldown, ItemTypes::writeUseCooldown, ObjectDataComponent::new);
-    public static final DataComponentType<Key> DAMAGE_RESISTANT = new DataComponentType<>("damage_resistant", MinecraftTypes::readResourceLocation, MinecraftTypes::writeResourceLocation, ObjectDataComponent::new);
-    public static final DataComponentType<ToolData> TOOL = new DataComponentType<>("tool", ItemTypes::readToolData, ItemTypes::writeToolData, ObjectDataComponent::new);
-    public static final IntComponentType ENCHANTABLE = new IntComponentType("enchantable", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final DataComponentType<Equippable> EQUIPPABLE = new DataComponentType<>("equippable", ItemTypes::readEquippable, ItemTypes::writeEquippable, ObjectDataComponent::new);
-    public static final DataComponentType<HolderSet> REPAIRABLE = new DataComponentType<>("repairable", MinecraftTypes::readHolderSet, MinecraftTypes::writeHolderSet, ObjectDataComponent::new);
-    public static final DataComponentType<Unit> GLIDER = new DataComponentType<>("glider", unitReader(), unitWriter(), ObjectDataComponent::new);
-    public static final DataComponentType<Key> TOOLTIP_STYLE = new DataComponentType<>("tooltip_style", MinecraftTypes::readResourceLocation, MinecraftTypes::writeResourceLocation, ObjectDataComponent::new);
-    public static final DataComponentType<List<ConsumeEffect>> DEATH_PROTECTION = new DataComponentType<>("death_protection", listReader(ItemTypes::readConsumeEffect), listWriter(ItemTypes::writeConsumeEffect), ObjectDataComponent::new);
-    public static final DataComponentType<ItemEnchantments> STORED_ENCHANTMENTS = new DataComponentType<>("stored_enchantments", ItemTypes::readItemEnchantments, ItemTypes::writeItemEnchantments, ObjectDataComponent::new);
-    public static final DataComponentType<DyedItemColor> DYED_COLOR = new DataComponentType<>("dyed_color", ItemTypes::readDyedItemColor, ItemTypes::writeDyedItemColor, ObjectDataComponent::new);
-    public static final IntComponentType MAP_COLOR = new IntComponentType("map_color", ByteBuf::readInt, ByteBuf::writeInt, IntDataComponent::new);
-    public static final IntComponentType MAP_ID = new IntComponentType("map_id", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final DataComponentType<NbtMap> MAP_DECORATIONS = new DataComponentType<>("map_decorations", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-    public static final IntComponentType MAP_POST_PROCESSING = new IntComponentType("map_post_processing", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final DataComponentType<List<ItemStack>> CHARGED_PROJECTILES = new DataComponentType<>("charged_projectiles", listReader(MinecraftTypes::readItemStack), listWriter(MinecraftTypes::writeItemStack), ObjectDataComponent::new);
-    public static final DataComponentType<List<ItemStack>> BUNDLE_CONTENTS = new DataComponentType<>("bundle_contents", listReader(MinecraftTypes::readItemStack), listWriter(MinecraftTypes::writeItemStack), ObjectDataComponent::new);
-    public static final DataComponentType<PotionContents> POTION_CONTENTS = new DataComponentType<>("potion_contents", ItemTypes::readPotionContents, ItemTypes::writePotionContents, ObjectDataComponent::new);
-    public static final DataComponentType<List<SuspiciousStewEffect>> SUSPICIOUS_STEW_EFFECTS = new DataComponentType<>("suspicious_stew_effects", listReader(ItemTypes::readStewEffect), listWriter(ItemTypes::writeStewEffect), ObjectDataComponent::new);
-    public static final DataComponentType<WritableBookContent> WRITABLE_BOOK_CONTENT = new DataComponentType<>("writable_book_content", ItemTypes::readWritableBookContent, ItemTypes::writeWritableBookContent, ObjectDataComponent::new);
-    public static final DataComponentType<WrittenBookContent> WRITTEN_BOOK_CONTENT = new DataComponentType<>("written_book_content", ItemTypes::readWrittenBookContent, ItemTypes::writeWrittenBookContent, ObjectDataComponent::new);
-    public static final DataComponentType<ArmorTrim> TRIM = new DataComponentType<>("trim", ItemTypes::readArmorTrim, ItemTypes::writeArmorTrim, ObjectDataComponent::new);
-    public static final DataComponentType<NbtMap> DEBUG_STICK_STATE = new DataComponentType<>("debug_stick_state", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-    public static final DataComponentType<NbtMap> ENTITY_DATA = new DataComponentType<>("entity_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-    public static final DataComponentType<NbtMap> BUCKET_ENTITY_DATA = new DataComponentType<>("bucket_entity_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-    public static final DataComponentType<NbtMap> BLOCK_ENTITY_DATA = new DataComponentType<>("block_entity_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-    public static final DataComponentType<Holder<Instrument>> INSTRUMENT = new DataComponentType<>("instrument", ItemTypes::readInstrument, ItemTypes::writeInstrument, ObjectDataComponent::new);
-    public static final IntComponentType OMINOUS_BOTTLE_AMPLIFIER = new IntComponentType("ominous_bottle_amplifier", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final DataComponentType<JukeboxPlayable> JUKEBOX_PLAYABLE = new DataComponentType<>("jukebox_playable", ItemTypes::readJukeboxPlayable, ItemTypes::writeJukeboxPlayable, ObjectDataComponent::new);
-    public static final DataComponentType<NbtList<?>> RECIPES = new DataComponentType<>("recipes", ItemTypes::readRecipes, ItemTypes::writeRecipes, ObjectDataComponent::new);
-    public static final DataComponentType<LodestoneTracker> LODESTONE_TRACKER = new DataComponentType<>("lodestone_tracker", ItemTypes::readLodestoneTarget, ItemTypes::writeLodestoneTarget, ObjectDataComponent::new);
-    public static final DataComponentType<Fireworks.FireworkExplosion> FIREWORK_EXPLOSION = new DataComponentType<>("firework_explosion", ItemTypes::readFireworkExplosion, ItemTypes::writeFireworkExplosion, ObjectDataComponent::new);
-    public static final DataComponentType<Fireworks> FIREWORKS = new DataComponentType<>("fireworks", ItemTypes::readFireworks, ItemTypes::writeFireworks, ObjectDataComponent::new);
-    public static final DataComponentType<GameProfile> PROFILE = new DataComponentType<>("profile", ItemTypes::readResolvableProfile, ItemTypes::writeResolvableProfile, ObjectDataComponent::new);
-    public static final DataComponentType<Key> NOTE_BLOCK_SOUND = new DataComponentType<>("note_block_sound", MinecraftTypes::readResourceLocation, MinecraftTypes::writeResourceLocation, ObjectDataComponent::new);
-    public static final DataComponentType<List<BannerPatternLayer>> BANNER_PATTERNS = new DataComponentType<>("banner_patterns", listReader(ItemTypes::readBannerPatternLayer), listWriter(ItemTypes::writeBannerPatternLayer), ObjectDataComponent::new);
-    public static final IntComponentType BASE_COLOR = new IntComponentType("base_color", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new);
-    public static final DataComponentType<List<Integer>> POT_DECORATIONS = new DataComponentType<>("pot_decorations", listReader(MinecraftTypes::readVarInt), listWriter(MinecraftTypes::writeVarInt), ObjectDataComponent::new);
-    public static final DataComponentType<List<ItemStack>> CONTAINER = new DataComponentType<>("container", listReader(MinecraftTypes::readOptionalItemStack), listWriter(MinecraftTypes::writeOptionalItemStack), ObjectDataComponent::new);
-    public static final DataComponentType<BlockStateProperties> BLOCK_STATE = new DataComponentType<>("block_state", ItemTypes::readBlockStateProperties, ItemTypes::writeBlockStateProperties, ObjectDataComponent::new);
-    public static final DataComponentType<List<BeehiveOccupant>> BEES = new DataComponentType<>("bees", listReader(ItemTypes::readBeehiveOccupant), listWriter(ItemTypes::writeBeehiveOccupant), ObjectDataComponent::new);
-    public static final DataComponentType<NbtMap> LOCK = new DataComponentType<>("lock", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-    public static final DataComponentType<NbtMap> CONTAINER_LOOT = new DataComponentType<>("container_loot", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new);
-
     protected final int id;
     protected final Key key;
     protected final Reader<T> reader;
     protected final Writer<T> writer;
     protected final DataComponentFactory<T> dataComponentFactory;
 
-    protected DataComponentType(@KeyPattern String key, Reader<T> reader, Writer<T> writer, DataComponentFactory<T> dataComponentFactory) {
-        this.id = VALUES.size();
+    protected DataComponentType(int id, @KeyPattern String key, Reader<T> reader, Writer<T> writer, DataComponentFactory<T> dataComponentFactory) {
+        this.id = id;
         this.key = Key.key(key);
         this.reader = reader;
         this.writer = writer;
         this.dataComponentFactory = dataComponentFactory;
-
-        VALUES.add(this);
     }
 
     public DataComponent<T, ? extends DataComponentType<T>> readDataComponent(ByteBuf input) {
@@ -141,53 +56,6 @@ public class DataComponentType<T> {
     @FunctionalInterface
     public interface DataComponentFactory<V> {
         DataComponent<V, ? extends DataComponentType<V>> create(DataComponentType<V> type, V value);
-    }
-
-    private static <T> Reader<List<T>> listReader(Reader<T> reader) {
-        return (input) -> {
-            List<T> ret = new ArrayList<>();
-            int size = MinecraftTypes.readVarInt(input);
-            for (int i = 0; i < size; i++) {
-                ret.add(reader.read(input));
-            }
-
-            return ret;
-        };
-    }
-
-    private static <T> Writer<List<T>> listWriter(Writer<T> writer) {
-        return (output, value) -> {
-            MinecraftTypes.writeVarInt(output, value.size());
-            for (T object : value) {
-                writer.write(output, object);
-            }
-        };
-    }
-
-    private static Reader<Unit> unitReader() {
-        return (input) -> Unit.INSTANCE;
-    }
-
-    private static Writer<Unit> unitWriter() {
-        return (output, value) -> {
-        };
-    }
-
-    public static DataComponentType<?> read(ByteBuf in) {
-        int id = MinecraftTypes.readVarInt(in);
-        if (id >= VALUES.size()) {
-            throw new IllegalArgumentException("Received id " + id + " for DataComponentType when the maximum was " + VALUES.size() + "!");
-        }
-
-        return VALUES.get(id);
-    }
-
-    public static DataComponentType<?> from(int id) {
-        return VALUES.get(id);
-    }
-
-    public static int size() {
-        return VALUES.size();
     }
 
     @Override

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentTypes.java
@@ -1,0 +1,145 @@
+package org.geysermc.mcprotocollib.protocol.data.game.item.component;
+
+import io.netty.buffer.ByteBuf;
+import it.unimi.dsi.fastutil.ints.Int2ObjectFunction;
+import lombok.Getter;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.text.Component;
+import org.cloudburstmc.nbt.NbtList;
+import org.cloudburstmc.nbt.NbtMap;
+import org.geysermc.mcprotocollib.auth.GameProfile;
+import org.geysermc.mcprotocollib.protocol.codec.MinecraftTypes;
+import org.geysermc.mcprotocollib.protocol.data.game.Holder;
+import org.geysermc.mcprotocollib.protocol.data.game.item.ItemStack;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.type.BooleanDataComponent;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.type.IntDataComponent;
+import org.geysermc.mcprotocollib.protocol.data.game.item.component.type.ObjectDataComponent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class DataComponentTypes<T> {
+    private static final List<DataComponentType<?>> VALUES = new ArrayList<>();
+
+    public static final DataComponentType<NbtMap> CUSTOM_DATA = register(id -> new DataComponentType<>(id, "custom_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+    public static final IntComponentType MAX_STACK_SIZE = register(id -> new IntComponentType(id, "max_stack_size", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final IntComponentType MAX_DAMAGE = register(id -> new IntComponentType(id, "max_damage", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final IntComponentType DAMAGE = register(id -> new IntComponentType(id, "damage", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final DataComponentType<Unbreakable> UNBREAKABLE = register(id -> new DataComponentType<>(id, "unbreakable", ItemTypes::readUnbreakable, ItemTypes::writeUnbreakable, ObjectDataComponent::new));
+    public static final DataComponentType<Component> CUSTOM_NAME = register(id -> new DataComponentType<>(id, "custom_name", MinecraftTypes::readComponent, MinecraftTypes::writeComponent, ObjectDataComponent::new));
+    public static final DataComponentType<Component> ITEM_NAME = register(id -> new DataComponentType<>(id, "item_name", MinecraftTypes::readComponent, MinecraftTypes::writeComponent, ObjectDataComponent::new));
+    public static final DataComponentType<Key> ITEM_MODEL = register(id -> new DataComponentType<>(id, "item_model", MinecraftTypes::readResourceLocation, MinecraftTypes::writeResourceLocation, ObjectDataComponent::new));
+    public static final DataComponentType<List<Component>> LORE = register(id -> new DataComponentType<>(id, "lore", listReader(MinecraftTypes::readComponent), listWriter(MinecraftTypes::writeComponent), ObjectDataComponent::new));
+    public static final IntComponentType RARITY = register(id -> new IntComponentType(id, "rarity", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final DataComponentType<ItemEnchantments> ENCHANTMENTS = register(id -> new DataComponentType<>(id, "enchantments", ItemTypes::readItemEnchantments, ItemTypes::writeItemEnchantments, ObjectDataComponent::new));
+    public static final DataComponentType<AdventureModePredicate> CAN_PLACE_ON = register(id -> new DataComponentType<>(id, "can_place_on", ItemTypes::readAdventureModePredicate, ItemTypes::writeAdventureModePredicate, ObjectDataComponent::new));
+    public static final DataComponentType<AdventureModePredicate> CAN_BREAK = register(id -> new DataComponentType<>(id, "can_break", ItemTypes::readAdventureModePredicate, ItemTypes::writeAdventureModePredicate, ObjectDataComponent::new));
+    public static final DataComponentType<ItemAttributeModifiers> ATTRIBUTE_MODIFIERS = register(id -> new DataComponentType<>(id, "attribute_modifiers", ItemTypes::readItemAttributeModifiers, ItemTypes::writeItemAttributeModifiers, ObjectDataComponent::new));
+    public static final DataComponentType<CustomModelData> CUSTOM_MODEL_DATA = register(id -> new DataComponentType<>(id, "custom_model_data", ItemTypes::readCustomModelData, ItemTypes::writeCustomModelData, ObjectDataComponent::new));
+    public static final DataComponentType<Unit> HIDE_ADDITIONAL_TOOLTIP = register(id -> new DataComponentType<>(id, "hide_additional_tooltip", unitReader(), unitWriter(), ObjectDataComponent::new));
+    public static final DataComponentType<Unit> HIDE_TOOLTIP = register(id -> new DataComponentType<>(id, "hide_tooltip", unitReader(), unitWriter(), ObjectDataComponent::new));
+    public static final IntComponentType REPAIR_COST = register(id -> new IntComponentType(id, "repair_cost", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final DataComponentType<Unit> CREATIVE_SLOT_LOCK = register(id -> new DataComponentType<>(id, "creative_slot_lock", unitReader(), unitWriter(), ObjectDataComponent::new));
+    public static final BooleanComponentType ENCHANTMENT_GLINT_OVERRIDE = register(id -> new BooleanComponentType(id, "enchantment_glint_override", ByteBuf::readBoolean, ByteBuf::writeBoolean, BooleanDataComponent::new));
+    public static final DataComponentType<NbtMap> INTANGIBLE_PROJECTILE = register(id -> new DataComponentType<>(id, "intangible_projectile", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+    public static final DataComponentType<FoodProperties> FOOD = register(id -> new DataComponentType<>(id, "food", ItemTypes::readFoodProperties, ItemTypes::writeFoodProperties, ObjectDataComponent::new));
+    public static final DataComponentType<Consumable> CONSUMABLE = register(id -> new DataComponentType<>(id, "consumable", ItemTypes::readConsumable, ItemTypes::writeConsumable, ObjectDataComponent::new));
+    public static final DataComponentType<ItemStack> USE_REMAINDER = register(id -> new DataComponentType<>(id, "use_remainder", MinecraftTypes::readItemStack, MinecraftTypes::writeItemStack, ObjectDataComponent::new));
+    public static final DataComponentType<UseCooldown> USE_COOLDOWN = register(id -> new DataComponentType<>(id, "use_cooldown", ItemTypes::readUseCooldown, ItemTypes::writeUseCooldown, ObjectDataComponent::new));
+    public static final DataComponentType<Key> DAMAGE_RESISTANT = register(id -> new DataComponentType<>(id, "damage_resistant", MinecraftTypes::readResourceLocation, MinecraftTypes::writeResourceLocation, ObjectDataComponent::new));
+    public static final DataComponentType<ToolData> TOOL = register(id -> new DataComponentType<>(id, "tool", ItemTypes::readToolData, ItemTypes::writeToolData, ObjectDataComponent::new));
+    public static final IntComponentType ENCHANTABLE = register(id -> new IntComponentType(id, "enchantable", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final DataComponentType<Equippable> EQUIPPABLE = register(id -> new DataComponentType<>(id, "equippable", ItemTypes::readEquippable, ItemTypes::writeEquippable, ObjectDataComponent::new));
+    public static final DataComponentType<HolderSet> REPAIRABLE = register(id -> new DataComponentType<>(id, "repairable", MinecraftTypes::readHolderSet, MinecraftTypes::writeHolderSet, ObjectDataComponent::new));
+    public static final DataComponentType<Unit> GLIDER = register(id -> new DataComponentType<>(id, "glider", unitReader(), unitWriter(), ObjectDataComponent::new));
+    public static final DataComponentType<Key> TOOLTIP_STYLE = register(id -> new DataComponentType<>(id, "tooltip_style", MinecraftTypes::readResourceLocation, MinecraftTypes::writeResourceLocation, ObjectDataComponent::new));
+    public static final DataComponentType<List<ConsumeEffect>> DEATH_PROTECTION = register(id -> new DataComponentType<>(id, "death_protection", listReader(ItemTypes::readConsumeEffect), listWriter(ItemTypes::writeConsumeEffect), ObjectDataComponent::new));
+    public static final DataComponentType<ItemEnchantments> STORED_ENCHANTMENTS = register(id -> new DataComponentType<>(id, "stored_enchantments", ItemTypes::readItemEnchantments, ItemTypes::writeItemEnchantments, ObjectDataComponent::new));
+    public static final DataComponentType<DyedItemColor> DYED_COLOR = register(id -> new DataComponentType<>(id, "dyed_color", ItemTypes::readDyedItemColor, ItemTypes::writeDyedItemColor, ObjectDataComponent::new));
+    public static final IntComponentType MAP_COLOR = register(id -> new IntComponentType(id, "map_color", ByteBuf::readInt, ByteBuf::writeInt, IntDataComponent::new));
+    public static final IntComponentType MAP_ID = register(id -> new IntComponentType(id, "map_id", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final DataComponentType<NbtMap> MAP_DECORATIONS = register(id -> new DataComponentType<>(id, "map_decorations", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+    public static final IntComponentType MAP_POST_PROCESSING = register(id -> new IntComponentType(id, "map_post_processing", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final DataComponentType<List<ItemStack>> CHARGED_PROJECTILES = register(id -> new DataComponentType<>(id, "charged_projectiles", listReader(MinecraftTypes::readItemStack), listWriter(MinecraftTypes::writeItemStack), ObjectDataComponent::new));
+    public static final DataComponentType<List<ItemStack>> BUNDLE_CONTENTS = register(id -> new DataComponentType<>(id, "bundle_contents", listReader(MinecraftTypes::readItemStack), listWriter(MinecraftTypes::writeItemStack), ObjectDataComponent::new));
+    public static final DataComponentType<PotionContents> POTION_CONTENTS = register(id -> new DataComponentType<>(id, "potion_contents", ItemTypes::readPotionContents, ItemTypes::writePotionContents, ObjectDataComponent::new));
+    public static final DataComponentType<List<SuspiciousStewEffect>> SUSPICIOUS_STEW_EFFECTS = register(id -> new DataComponentType<>(id, "suspicious_stew_effects", listReader(ItemTypes::readStewEffect), listWriter(ItemTypes::writeStewEffect), ObjectDataComponent::new));
+    public static final DataComponentType<WritableBookContent> WRITABLE_BOOK_CONTENT = register(id -> new DataComponentType<>(id, "writable_book_content", ItemTypes::readWritableBookContent, ItemTypes::writeWritableBookContent, ObjectDataComponent::new));
+    public static final DataComponentType<WrittenBookContent> WRITTEN_BOOK_CONTENT = register(id -> new DataComponentType<>(id, "written_book_content", ItemTypes::readWrittenBookContent, ItemTypes::writeWrittenBookContent, ObjectDataComponent::new));
+    public static final DataComponentType<ArmorTrim> TRIM = register(id -> new DataComponentType<>(id, "trim", ItemTypes::readArmorTrim, ItemTypes::writeArmorTrim, ObjectDataComponent::new));
+    public static final DataComponentType<NbtMap> DEBUG_STICK_STATE = register(id -> new DataComponentType<>(id, "debug_stick_state", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+    public static final DataComponentType<NbtMap> ENTITY_DATA = register(id -> new DataComponentType<>(id, "entity_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+    public static final DataComponentType<NbtMap> BUCKET_ENTITY_DATA = register(id -> new DataComponentType<>(id, "bucket_entity_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+    public static final DataComponentType<NbtMap> BLOCK_ENTITY_DATA = register(id -> new DataComponentType<>(id, "block_entity_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+    public static final DataComponentType<Holder<Instrument>> INSTRUMENT = register(id -> new DataComponentType<>(id, "instrument", ItemTypes::readInstrument, ItemTypes::writeInstrument, ObjectDataComponent::new));
+    public static final IntComponentType OMINOUS_BOTTLE_AMPLIFIER = register(id -> new IntComponentType(id, "ominous_bottle_amplifier", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final DataComponentType<JukeboxPlayable> JUKEBOX_PLAYABLE = register(id -> new DataComponentType<>(id, "jukebox_playable", ItemTypes::readJukeboxPlayable, ItemTypes::writeJukeboxPlayable, ObjectDataComponent::new));
+    public static final DataComponentType<NbtList<?>> RECIPES = register(id -> new DataComponentType<>(id, "recipes", ItemTypes::readRecipes, ItemTypes::writeRecipes, ObjectDataComponent::new));
+    public static final DataComponentType<LodestoneTracker> LODESTONE_TRACKER = register(id -> new DataComponentType<>(id, "lodestone_tracker", ItemTypes::readLodestoneTarget, ItemTypes::writeLodestoneTarget, ObjectDataComponent::new));
+    public static final DataComponentType<Fireworks.FireworkExplosion> FIREWORK_EXPLOSION = register(id -> new DataComponentType<>(id, "firework_explosion", ItemTypes::readFireworkExplosion, ItemTypes::writeFireworkExplosion, ObjectDataComponent::new));
+    public static final DataComponentType<Fireworks> FIREWORKS = register(id -> new DataComponentType<>(id, "fireworks", ItemTypes::readFireworks, ItemTypes::writeFireworks, ObjectDataComponent::new));
+    public static final DataComponentType<GameProfile> PROFILE = register(id -> new DataComponentType<>(id, "profile", ItemTypes::readResolvableProfile, ItemTypes::writeResolvableProfile, ObjectDataComponent::new));
+    public static final DataComponentType<Key> NOTE_BLOCK_SOUND = register(id -> new DataComponentType<>(id, "note_block_sound", MinecraftTypes::readResourceLocation, MinecraftTypes::writeResourceLocation, ObjectDataComponent::new));
+    public static final DataComponentType<List<BannerPatternLayer>> BANNER_PATTERNS = register(id -> new DataComponentType<>(id, "banner_patterns", listReader(ItemTypes::readBannerPatternLayer), listWriter(ItemTypes::writeBannerPatternLayer), ObjectDataComponent::new));
+    public static final IntComponentType BASE_COLOR = register(id -> new IntComponentType(id, "base_color", MinecraftTypes::readVarInt, MinecraftTypes::writeVarInt, IntDataComponent::new));
+    public static final DataComponentType<List<Integer>> POT_DECORATIONS = register(id -> new DataComponentType<>(id, "pot_decorations", listReader(MinecraftTypes::readVarInt), listWriter(MinecraftTypes::writeVarInt), ObjectDataComponent::new));
+    public static final DataComponentType<List<ItemStack>> CONTAINER = register(id -> new DataComponentType<>(id, "container", listReader(MinecraftTypes::readOptionalItemStack), listWriter(MinecraftTypes::writeOptionalItemStack), ObjectDataComponent::new));
+    public static final DataComponentType<BlockStateProperties> BLOCK_STATE = register(id -> new DataComponentType<>(id, "block_state", ItemTypes::readBlockStateProperties, ItemTypes::writeBlockStateProperties, ObjectDataComponent::new));
+    public static final DataComponentType<List<BeehiveOccupant>> BEES = register(id -> new DataComponentType<>(id, "bees", listReader(ItemTypes::readBeehiveOccupant), listWriter(ItemTypes::writeBeehiveOccupant), ObjectDataComponent::new));
+    public static final DataComponentType<NbtMap> LOCK = register(id -> new DataComponentType<>(id, "lock", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+    public static final DataComponentType<NbtMap> CONTAINER_LOOT = register(id -> new DataComponentType<>(id, "container_loot", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));
+
+    public static <T extends DataComponentType<?>> T register(Int2ObjectFunction<T> factory) {
+        T value = factory.apply(VALUES.size());
+        VALUES.add(value);
+        return value;
+    }
+
+    private static <T> DataComponentType.Reader<List<T>> listReader(DataComponentType.Reader<T> reader) {
+        return (input) -> {
+            List<T> ret = new ArrayList<>();
+            int size = MinecraftTypes.readVarInt(input);
+            for (int i = 0; i < size; i++) {
+                ret.add(reader.read(input));
+            }
+
+            return ret;
+        };
+    }
+
+    private static <T> DataComponentType.Writer<List<T>> listWriter(DataComponentType.Writer<T> writer) {
+        return (output, value) -> {
+            MinecraftTypes.writeVarInt(output, value.size());
+            for (T object : value) {
+                writer.write(output, object);
+            }
+        };
+    }
+
+    private static DataComponentType.Reader<Unit> unitReader() {
+        return (input) -> Unit.INSTANCE;
+    }
+
+    private static DataComponentType.Writer<Unit> unitWriter() {
+        return (output, value) -> {
+        };
+    }
+
+    public static DataComponentType<?> read(ByteBuf in) {
+        int id = MinecraftTypes.readVarInt(in);
+        if (id >= VALUES.size()) {
+            throw new IllegalArgumentException("Received id " + id + " for DataComponentType when the maximum was " + VALUES.size() + "!");
+        }
+
+        return VALUES.get(id);
+    }
+
+    public static DataComponentType<?> from(int id) {
+        return VALUES.get(id);
+    }
+
+    public static int size() {
+        return VALUES.size();
+    }
+}

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponents.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponents.java
@@ -14,6 +14,7 @@ public class DataComponents {
     private final Map<DataComponentType<?>, DataComponent<?, ?>> dataComponents;
 
     @Nullable
+    @SuppressWarnings("unchecked")
     public <T> T get(DataComponentType<T> type) {
         DataComponent<?, ?> component = dataComponents.get(type);
         return component == null ? null : (T) component.getValue();
@@ -34,7 +35,7 @@ public class DataComponents {
         }
     }
 
-    public DataComponents copy() {
+    public DataComponents clone() {
         return new DataComponents(new HashMap<>(dataComponents));
     }
 }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponents.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponents.java
@@ -15,7 +15,7 @@ public class DataComponents {
 
     @Nullable
     public <T> T get(DataComponentType<T> type) {
-        DataComponent component = dataComponents.get(type);
+        DataComponent<?, ?> component = dataComponents.get(type);
         return component == null ? null : (T) component.getValue();
     }
 
@@ -34,7 +34,7 @@ public class DataComponents {
         }
     }
 
-    public DataComponents clone() {
+    public DataComponents copy() {
         return new DataComponents(new HashMap<>(dataComponents));
     }
 }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/IntComponentType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/IntComponentType.java
@@ -9,8 +9,8 @@ public class IntComponentType extends DataComponentType<Integer> {
     protected final IntWriter primitiveWriter;
     protected final IntDataComponentFactory primitiveFactory;
 
-    protected IntComponentType(@KeyPattern String key, IntReader reader, IntWriter writer, IntDataComponentFactory metadataFactory) {
-        super(key, reader, writer, metadataFactory);
+    protected IntComponentType(int id, @KeyPattern String key, IntReader reader, IntWriter writer, IntDataComponentFactory metadataFactory) {
+        super(id, key, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;
         this.primitiveWriter = writer;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/IntComponentType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/IntComponentType.java
@@ -1,6 +1,7 @@
 package org.geysermc.mcprotocollib.protocol.data.game.item.component;
 
 import io.netty.buffer.ByteBuf;
+import net.kyori.adventure.key.KeyPattern;
 import org.geysermc.mcprotocollib.protocol.data.game.item.component.type.IntDataComponent;
 
 public class IntComponentType extends DataComponentType<Integer> {
@@ -8,7 +9,7 @@ public class IntComponentType extends DataComponentType<Integer> {
     protected final IntWriter primitiveWriter;
     protected final IntDataComponentFactory primitiveFactory;
 
-    protected IntComponentType(String key, IntReader reader, IntWriter writer, IntDataComponentFactory metadataFactory) {
+    protected IntComponentType(@KeyPattern String key, IntReader reader, IntWriter writer, IntDataComponentFactory metadataFactory) {
         super(key, reader, writer, metadataFactory);
 
         this.primitiveReader = reader;

--- a/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/packet/ingame/clientbound/level/ClientboundSetEntityDataPacketTest.java
+++ b/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/packet/ingame/clientbound/level/ClientboundSetEntityDataPacketTest.java
@@ -2,7 +2,7 @@ package org.geysermc.mcprotocollib.protocol.packet.ingame.clientbound.level;
 
 import org.cloudburstmc.math.vector.Vector3i;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.EntityMetadata;
-import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.MetadataType;
+import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.MetadataTypes;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.BooleanEntityMetadata;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.ByteEntityMetadata;
 import org.geysermc.mcprotocollib.protocol.data.game.entity.metadata.type.FloatEntityMetadata;
@@ -23,23 +23,23 @@ public class ClientboundSetEntityDataPacketTest extends PacketTest {
         this.setPackets(
                 new ClientboundSetEntityDataPacket(0, new EntityMetadata<?, ?>[0]),
                 new ClientboundSetEntityDataPacket(20, new EntityMetadata<?, ?>[]{
-                        new ObjectEntityMetadata<>(1, MetadataType.STRING, "Hello!")
+                        new ObjectEntityMetadata<>(1, MetadataTypes.STRING, "Hello!")
                 }),
                 new ClientboundSetEntityDataPacket(2, new EntityMetadata<?, ?>[]{
-                        new BooleanEntityMetadata(0, MetadataType.BOOLEAN, true),
-                        new ByteEntityMetadata(4, MetadataType.BYTE, (byte) 45),
-                        new IntEntityMetadata(2, MetadataType.INT, 555),
-                        new FloatEntityMetadata(3, MetadataType.FLOAT, 3.0f),
-                        new LongEntityMetadata(8, MetadataType.LONG, 123456789L),
-                        new ObjectEntityMetadata<>(5, MetadataType.POSITION, Vector3i.from(0, 1, 0)),
-                        new ObjectEntityMetadata<>(2, MetadataType.BLOCK_STATE, 60),
-                        new ObjectEntityMetadata<>(6, MetadataType.DIRECTION, Direction.EAST),
-                        new ObjectEntityMetadata<>(7, MetadataType.OPTIONAL_VARINT, OptionalInt.of(1038))
+                        new BooleanEntityMetadata(0, MetadataTypes.BOOLEAN, true),
+                        new ByteEntityMetadata(4, MetadataTypes.BYTE, (byte) 45),
+                        new IntEntityMetadata(2, MetadataTypes.INT, 555),
+                        new FloatEntityMetadata(3, MetadataTypes.FLOAT, 3.0f),
+                        new LongEntityMetadata(8, MetadataTypes.LONG, 123456789L),
+                        new ObjectEntityMetadata<>(5, MetadataTypes.POSITION, Vector3i.from(0, 1, 0)),
+                        new ObjectEntityMetadata<>(2, MetadataTypes.BLOCK_STATE, 60),
+                        new ObjectEntityMetadata<>(6, MetadataTypes.DIRECTION, Direction.EAST),
+                        new ObjectEntityMetadata<>(7, MetadataTypes.OPTIONAL_VARINT, OptionalInt.of(1038))
                 }),
                 new ClientboundSetEntityDataPacket(700, new EntityMetadata<?, ?>[]{
                         // Boxed variation test
-                        new ObjectEntityMetadata<>(0, MetadataType.INT, 0),
-                        new ObjectEntityMetadata<>(1, MetadataType.FLOAT, 1.0f)
+                        new ObjectEntityMetadata<>(0, MetadataTypes.INT, 0),
+                        new ObjectEntityMetadata<>(1, MetadataTypes.FLOAT, 1.0f)
                 })
         );
     }


### PR DESCRIPTION
This is mainly to avoid thread deadlocking issues that may occur from a parent class early initializing child classes. The other reason is that this is cleaner and makes the code for MetadataTypes more readable. It also simplifies the initialization of metadatatypes by adding id as a constructor.