### PR TITLE
Fix vanilla order, this will resolve invisible player issues.

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/PlayerListEntryAction.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/PlayerListEntryAction.java
@@ -7,8 +7,8 @@ public enum PlayerListEntryAction {
     UPDATE_LISTED,
     UPDATE_LATENCY,
     UPDATE_DISPLAY_NAME,
-    UPDATE_HAT,
-    UPDATE_LIST_ORDER;
+    UPDATE_LIST_ORDER,
+    UPDATE_HAT;
 
     public static final PlayerListEntryAction[] VALUES = values();
 


### PR DESCRIPTION
This change on the enum poisiton affects the bitset reading so the info packets aren't being read properly currently, this hsould fix the issue 