### PR TITLE
Fix/write race condition

### DIFF
--- a/example/src/main/java/org/geysermc/mcprotocollib/network/example/TestProtocol.java
+++ b/example/src/main/java/org/geysermc/mcprotocollib/network/example/TestProtocol.java
@@ -9,8 +9,8 @@ import org.geysermc.mcprotocollib.network.crypt.AESEncryption;
 import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 import org.geysermc.mcprotocollib.network.packet.DefaultPacketHeader;
 import org.geysermc.mcprotocollib.network.packet.PacketHeader;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.packet.PacketRegistry;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 import org.geysermc.mcprotocollib.protocol.codec.MinecraftTypes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 import javax.crypto.SecretKey;
 import java.security.GeneralSecurityException;
 
-public class TestProtocol extends PacketProtocol {
+public class TestProtocol extends MinecraftProtocol {
     private static final Logger log = LoggerFactory.getLogger(TestProtocol.class);
     private final PacketHeader header = new DefaultPacketHeader();
     private final PacketRegistry registry = new PacketRegistry();

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Server.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Server.java
@@ -1,8 +1,8 @@
 package org.geysermc.mcprotocollib.network;
 
 import org.geysermc.mcprotocollib.network.event.server.ServerListener;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.server.AbstractServer;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.SocketAddress;
 import java.util.List;
@@ -25,7 +25,7 @@ public interface Server {
      *
      * @return The server's packet protocol.
      */
-    Supplier<? extends PacketProtocol> getPacketProtocol();
+    Supplier<? extends MinecraftProtocol> getPacketProtocol();
 
     /**
      * Returns true if the listener is listening.

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/Session.java
@@ -10,7 +10,7 @@ import org.geysermc.mcprotocollib.network.event.session.SessionEvent;
 import org.geysermc.mcprotocollib.network.event.session.SessionListener;
 import org.geysermc.mcprotocollib.network.netty.FlushHandler;
 import org.geysermc.mcprotocollib.network.packet.Packet;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.SocketAddress;
 import java.util.List;
@@ -42,7 +42,7 @@ public interface Session {
      *
      * @return The session's packet protocol.
      */
-    PacketProtocol getPacketProtocol();
+    MinecraftProtocol getPacketProtocol();
 
     /**
      * Gets this session's set flags. If this session belongs to a server, the server's

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/event/session/PacketSendingEvent.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/event/session/PacketSendingEvent.java
@@ -34,17 +34,11 @@ public class PacketSendingEvent implements SessionEvent {
     /**
      * Gets the packet involved in this event as the required type.
      *
-     * @param <T> Type of the packet.
      * @return The event's packet as the required type.
      * @throws IllegalStateException If the packet's value isn't of the required type.
      */
-    @SuppressWarnings("unchecked")
-    public <T extends Packet> T getPacket() {
-        try {
-            return (T) this.packet;
-        } catch (ClassCastException e) {
-            throw new IllegalStateException("Tried to get packet as the wrong type. Actual type: " + this.packet.getClass().getName());
-        }
+    public Packet getPacket() {
+        return this.packet;
     }
 
     /**

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/factory/ClientNetworkSessionFactory.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/factory/ClientNetworkSessionFactory.java
@@ -5,8 +5,8 @@ import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.geysermc.mcprotocollib.network.ProxyInfo;
 import org.geysermc.mcprotocollib.network.netty.DefaultPacketHandlerExecutor;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.session.ClientNetworkSession;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -18,7 +18,7 @@ import java.util.concurrent.Executor;
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public final class ClientNetworkSessionFactory {
     private SocketAddress remoteSocketAddress;
-    private PacketProtocol protocol;
+    private MinecraftProtocol protocol;
     private Executor packetHandlerExecutor;
     private SocketAddress bindSocketAddress;
     private ProxyInfo proxy;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/MinecraftChannelInitializer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/MinecraftChannelInitializer.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.geysermc.mcprotocollib.network.BuiltinFlags;
 import org.geysermc.mcprotocollib.network.NetworkConstants;
 import org.geysermc.mcprotocollib.network.Session;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.util.function.Function;
 
@@ -31,7 +31,7 @@ public class MinecraftChannelInitializer<S extends Session & ChannelHandler> ext
     }
 
     protected void addHandlers(S session, Channel ch) {
-        PacketProtocol protocol = session.getPacketProtocol();
+        MinecraftProtocol protocol = session.getPacketProtocol();
         ChannelPipeline pipeline = ch.pipeline();
 
         pipeline.addLast(NetworkConstants.READ_TIMEOUT_NAME, new ReadTimeoutHandler(session.getFlag(BuiltinFlags.READ_TIMEOUT, 30)));

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCodec.java
@@ -3,6 +3,8 @@ package org.geysermc.mcprotocollib.network.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.ByteToMessageCodec;
+import io.netty.handler.codec.DecoderException;
+import io.netty.handler.codec.EncoderException;
 import org.geysermc.mcprotocollib.network.Session;
 import org.geysermc.mcprotocollib.network.codec.PacketDefinition;
 import org.geysermc.mcprotocollib.network.event.session.PacketErrorEvent;
@@ -57,7 +59,7 @@ public class PacketCodec extends ByteToMessageCodec<Packet> {
             PacketErrorEvent e = new PacketErrorEvent(this.session, t, packet);
             this.session.callEvent(e);
             if (!e.shouldSuppress()) {
-                throw t;
+                throw new EncoderException(t);
             }
         }
     }
@@ -103,7 +105,7 @@ public class PacketCodec extends ByteToMessageCodec<Packet> {
             PacketErrorEvent e = new PacketErrorEvent(this.session, t, packet);
             this.session.callEvent(e);
             if (!e.shouldSuppress()) {
-                throw t;
+                throw new DecoderException(t);
             }
         } finally {
             if (packet != null && packet.isTerminal()) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCodec.java
@@ -2,9 +2,7 @@ package org.geysermc.mcprotocollib.network.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.DecoderException;
-import io.netty.handler.codec.EncoderException;
-import io.netty.handler.codec.MessageToMessageCodec;
+import io.netty.handler.codec.ByteToMessageCodec;
 import org.geysermc.mcprotocollib.network.Session;
 import org.geysermc.mcprotocollib.network.codec.PacketDefinition;
 import org.geysermc.mcprotocollib.network.event.session.PacketErrorEvent;
@@ -18,7 +16,7 @@ import org.slf4j.MarkerFactory;
 
 import java.util.List;
 
-public class PacketCodec extends MessageToMessageCodec<ByteBuf, Packet> {
+public class PacketCodec extends ByteToMessageCodec<Packet> {
     private static final Marker marker = MarkerFactory.getMarker("packet_logging");
     private static final Logger log = LoggerFactory.getLogger(PacketCodec.class);
 
@@ -32,22 +30,20 @@ public class PacketCodec extends MessageToMessageCodec<ByteBuf, Packet> {
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     @Override
-    public void encode(ChannelHandlerContext ctx, Packet packet, List<Object> out) {
+    public void encode(ChannelHandlerContext ctx, Packet packet, ByteBuf out) {
         if (log.isTraceEnabled()) {
             log.trace(marker, "Encoding packet: {}", packet.getClass().getSimpleName());
         }
 
+        int initial = out.writerIndex();
         PacketProtocol packetProtocol = this.session.getPacketProtocol();
         PacketRegistry packetRegistry = packetProtocol.getOutboundPacketRegistry();
         try {
             int packetId = this.client ? packetRegistry.getServerboundId(packet) : packetRegistry.getClientboundId(packet);
             PacketDefinition definition = this.client ? packetRegistry.getServerboundDefinition(packetId) : packetRegistry.getClientboundDefinition(packetId);
 
-            ByteBuf buf = ctx.alloc().buffer();
-            packetProtocol.getPacketHeader().writePacketId(buf, packetId);
-            definition.getSerializer().serialize(buf, packet);
-
-            out.add(buf);
+            packetProtocol.getPacketHeader().writePacketId(out, packetId);
+            definition.getSerializer().serialize(out, packet);
 
             if (log.isDebugEnabled()) {
                 log.debug(marker, "Encoded packet {} ({})", packet.getClass().getSimpleName(), packetId);
@@ -55,10 +51,13 @@ public class PacketCodec extends MessageToMessageCodec<ByteBuf, Packet> {
         } catch (Throwable t) {
             log.debug(marker, "Error encoding packet", t);
 
+            // Reset writer index to make sure incomplete data is not written out.
+            out.writerIndex(initial);
+
             PacketErrorEvent e = new PacketErrorEvent(this.session, t, packet);
             this.session.callEvent(e);
             if (!e.shouldSuppress()) {
-                throw new EncoderException(t);
+                throw t;
             }
         }
     }
@@ -104,7 +103,7 @@ public class PacketCodec extends MessageToMessageCodec<ByteBuf, Packet> {
             PacketErrorEvent e = new PacketErrorEvent(this.session, t, packet);
             this.session.callEvent(e);
             if (!e.shouldSuppress()) {
-                throw new DecoderException(t);
+                throw t;
             }
         } finally {
             if (packet != null && packet.isTerminal()) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCodec.java
@@ -7,8 +7,8 @@ import org.geysermc.mcprotocollib.network.Session;
 import org.geysermc.mcprotocollib.network.codec.PacketDefinition;
 import org.geysermc.mcprotocollib.network.event.session.PacketErrorEvent;
 import org.geysermc.mcprotocollib.network.packet.Packet;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.packet.PacketRegistry;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
@@ -36,7 +36,7 @@ public class PacketCodec extends ByteToMessageCodec<Packet> {
         }
 
         int initial = out.writerIndex();
-        PacketProtocol packetProtocol = this.session.getPacketProtocol();
+        MinecraftProtocol packetProtocol = this.session.getPacketProtocol();
         PacketRegistry packetRegistry = packetProtocol.getOutboundPacketRegistry();
         try {
             int packetId = this.client ? packetRegistry.getServerboundId(packet) : packetRegistry.getClientboundId(packet);
@@ -71,7 +71,7 @@ public class PacketCodec extends ByteToMessageCodec<Packet> {
 
         int initial = buf.readerIndex();
 
-        PacketProtocol packetProtocol = this.session.getPacketProtocol();
+        MinecraftProtocol packetProtocol = this.session.getPacketProtocol();
         PacketRegistry packetRegistry = packetProtocol.getInboundPacketRegistry();
         Packet packet = null;
         try {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCompressionCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCompressionCodec.java
@@ -2,8 +2,8 @@ package org.geysermc.mcprotocollib.network.netty;
 
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageCodec;
 import io.netty.handler.codec.DecoderException;
-import io.netty.handler.codec.MessageToMessageCodec;
 import lombok.RequiredArgsConstructor;
 import org.geysermc.mcprotocollib.network.NetworkConstants;
 import org.geysermc.mcprotocollib.network.compression.CompressionConfig;
@@ -12,7 +12,7 @@ import org.geysermc.mcprotocollib.protocol.codec.MinecraftTypes;
 import java.util.List;
 
 @RequiredArgsConstructor
-public class PacketCompressionCodec extends MessageToMessageCodec<ByteBuf, ByteBuf> {
+public class PacketCompressionCodec extends ByteToMessageCodec<ByteBuf> {
     private static final int MAX_UNCOMPRESSED_SIZE = 8 * 1024 * 1024; // 8MiB
 
     @Override
@@ -26,10 +26,10 @@ public class PacketCompressionCodec extends MessageToMessageCodec<ByteBuf, ByteB
     }
 
     @Override
-    public void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) {
+    public void encode(ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out) {
         CompressionConfig config = ctx.channel().attr(NetworkConstants.COMPRESSION_ATTRIBUTE_KEY).get();
         if (config == null) {
-            out.add(msg.retain());
+            out.writeBytes(msg);
             return;
         }
 
@@ -48,7 +48,7 @@ public class PacketCompressionCodec extends MessageToMessageCodec<ByteBuf, ByteB
             config.compression().deflate(msg, outBuf);
         }
 
-        out.add(outBuf);
+        out.writeBytes(outBuf);
     }
 
     @Override

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCompressionCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCompressionCodec.java
@@ -39,16 +39,20 @@ public class PacketCompressionCodec extends ByteToMessageCodec<ByteBuf> {
         }
 
         ByteBuf outBuf = ctx.alloc().directBuffer(uncompressed);
-        if (uncompressed < config.threshold()) {
-            // Under the threshold, there is nothing to do.
-            MinecraftTypes.writeVarInt(outBuf, 0);
-            outBuf.writeBytes(msg);
-        } else {
-            MinecraftTypes.writeVarInt(outBuf, uncompressed);
-            config.compression().deflate(msg, outBuf);
-        }
+        try {
+            if (uncompressed < config.threshold()) {
+                // Under the threshold, there is nothing to do.
+                MinecraftTypes.writeVarInt(outBuf, 0);
+                outBuf.writeBytes(msg);
+            } else {
+                MinecraftTypes.writeVarInt(outBuf, uncompressed);
+                config.compression().deflate(msg, outBuf);
+            }
 
-        out.writeBytes(outBuf);
+            out.writeBytes(outBuf);
+        } finally {
+            outBuf.release();
+        }
     }
 
     @Override

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCompressionCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketCompressionCodec.java
@@ -55,13 +55,13 @@ public class PacketCompressionCodec extends ByteToMessageCodec<ByteBuf> {
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         CompressionConfig config = ctx.channel().attr(NetworkConstants.COMPRESSION_ATTRIBUTE_KEY).get();
         if (config == null) {
-            out.add(in.retain());
+            out.add(in.readBytes(in.readableBytes()));
             return;
         }
 
         int claimedUncompressedSize = MinecraftTypes.readVarInt(in);
         if (claimedUncompressedSize == 0) {
-            out.add(in.retain());
+            out.add(in.readBytes(in.readableBytes()));
             return;
         }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketEncryptorCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketEncryptorCodec.java
@@ -29,8 +29,9 @@ public class PacketEncryptorCodec extends ByteToMessageCodec<ByteBuf> {
             config.encryption().encrypt(heapBuf.array(), baseOffset, inBytes, heapBuf.array(), baseOffset);
             out.writeBytes(heapBuf);
         } catch (Exception e) {
-            heapBuf.release();
             throw new EncoderException("Error encrypting packet", e);
+        } finally {
+            heapBuf.release();
         }
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketEncryptorCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketEncryptorCodec.java
@@ -38,7 +38,7 @@ public class PacketEncryptorCodec extends ByteToMessageCodec<ByteBuf> {
     protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         EncryptionConfig config = ctx.channel().attr(NetworkConstants.ENCRYPTION_ATTRIBUTE_KEY).get();
         if (config == null) {
-            out.add(in.retain());
+            out.add(in.readBytes(in.readableBytes()));
             return;
         }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketEncryptorCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketEncryptorCodec.java
@@ -3,20 +3,20 @@ package org.geysermc.mcprotocollib.network.netty;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageCodec;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.EncoderException;
-import io.netty.handler.codec.MessageToMessageCodec;
 import org.geysermc.mcprotocollib.network.NetworkConstants;
 import org.geysermc.mcprotocollib.network.crypt.EncryptionConfig;
 
 import java.util.List;
 
-public class PacketEncryptorCodec extends MessageToMessageCodec<ByteBuf, ByteBuf> {
+public class PacketEncryptorCodec extends ByteToMessageCodec<ByteBuf> {
     @Override
-    public void encode(ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) {
+    public void encode(ChannelHandlerContext ctx, ByteBuf msg, ByteBuf out) {
         EncryptionConfig config = ctx.channel().attr(NetworkConstants.ENCRYPTION_ATTRIBUTE_KEY).get();
         if (config == null) {
-            out.add(msg.retain());
+            out.writeBytes(msg);
             return;
         }
 
@@ -27,7 +27,7 @@ public class PacketEncryptorCodec extends MessageToMessageCodec<ByteBuf, ByteBuf
 
         try {
             config.encryption().encrypt(heapBuf.array(), baseOffset, inBytes, heapBuf.array(), baseOffset);
-            out.add(heapBuf);
+            out.writeBytes(heapBuf);
         } catch (Exception e) {
             heapBuf.release();
             throw new EncoderException("Error encrypting packet", e);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketSizerCodec.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/netty/PacketSizerCodec.java
@@ -29,30 +29,30 @@ public class PacketSizerCodec extends ByteToMessageCodec<ByteBuf> {
     }
 
     @Override
-    protected void decode(ChannelHandlerContext ctx, ByteBuf buf, List<Object> out) {
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) {
         int size = header.getLengthSize();
         if (size == 0) {
-            out.add(buf.retain());
+            out.add(in.readBytes(in.readableBytes()));
             return;
         }
 
-        buf.markReaderIndex();
+        in.markReaderIndex();
         byte[] lengthBytes = new byte[size];
         for (int index = 0; index < lengthBytes.length; index++) {
-            if (!buf.isReadable()) {
-                buf.resetReaderIndex();
+            if (!in.isReadable()) {
+                in.resetReaderIndex();
                 return;
             }
 
-            lengthBytes[index] = buf.readByte();
+            lengthBytes[index] = in.readByte();
             if ((header.isLengthVariable() && lengthBytes[index] >= 0) || index == size - 1) {
-                int length = header.readLength(Unpooled.wrappedBuffer(lengthBytes), buf.readableBytes());
-                if (buf.readableBytes() < length) {
-                    buf.resetReaderIndex();
+                int length = header.readLength(Unpooled.wrappedBuffer(lengthBytes), in.readableBytes());
+                if (in.readableBytes() < length) {
+                    in.resetReaderIndex();
                     return;
                 }
 
-                out.add(buf.readBytes(length));
+                out.add(in.readBytes(length));
                 return;
             }
         }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/server/AbstractServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/server/AbstractServer.java
@@ -11,7 +11,7 @@ import org.geysermc.mcprotocollib.network.event.server.ServerEvent;
 import org.geysermc.mcprotocollib.network.event.server.ServerListener;
 import org.geysermc.mcprotocollib.network.event.server.SessionAddedEvent;
 import org.geysermc.mcprotocollib.network.event.server.SessionRemovedEvent;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.SocketAddress;
 import java.util.ArrayList;
@@ -23,14 +23,14 @@ import java.util.function.Supplier;
 
 public abstract class AbstractServer implements Server {
     private final SocketAddress bindAddress;
-    private final Supplier<? extends PacketProtocol> protocolSupplier;
+    private final Supplier<? extends MinecraftProtocol> protocolSupplier;
 
     private final List<Session> sessions = new ArrayList<>();
 
     private final Map<String, Object> flags = new HashMap<>();
     private final List<ServerListener> listeners = new ArrayList<>();
 
-    public AbstractServer(SocketAddress bindAddress, Supplier<? extends PacketProtocol> protocolSupplier) {
+    public AbstractServer(SocketAddress bindAddress, Supplier<? extends MinecraftProtocol> protocolSupplier) {
         this.bindAddress = bindAddress;
         this.protocolSupplier = protocolSupplier;
     }
@@ -41,11 +41,11 @@ public abstract class AbstractServer implements Server {
     }
 
     @Override
-    public Supplier<? extends PacketProtocol> getPacketProtocol() {
+    public Supplier<? extends MinecraftProtocol> getPacketProtocol() {
         return this.protocolSupplier;
     }
 
-    protected PacketProtocol createPacketProtocol() {
+    protected MinecraftProtocol createPacketProtocol() {
         return this.protocolSupplier.get();
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/server/NetworkServer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/server/NetworkServer.java
@@ -12,9 +12,9 @@ import org.geysermc.mcprotocollib.network.BuiltinFlags;
 import org.geysermc.mcprotocollib.network.helper.TransportHelper;
 import org.geysermc.mcprotocollib.network.netty.DefaultPacketHandlerExecutor;
 import org.geysermc.mcprotocollib.network.netty.MinecraftChannelInitializer;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.session.NetworkSession;
 import org.geysermc.mcprotocollib.network.session.ServerNetworkSession;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,11 +31,11 @@ public class NetworkServer extends AbstractServer {
     private EventLoopGroup workerGroup;
     private Channel channel;
 
-    public NetworkServer(SocketAddress bindAddress, Supplier<? extends PacketProtocol> protocol) {
+    public NetworkServer(SocketAddress bindAddress, Supplier<? extends MinecraftProtocol> protocol) {
         this(bindAddress, protocol, DefaultPacketHandlerExecutor::createExecutor);
     }
 
-    public NetworkServer(SocketAddress bindAddress, Supplier<? extends PacketProtocol> protocol, Supplier<Executor> packetHandlerExecutorFactory) {
+    public NetworkServer(SocketAddress bindAddress, Supplier<? extends MinecraftProtocol> protocol, Supplier<Executor> packetHandlerExecutorFactory) {
         super(bindAddress, protocol);
         this.packetHandlerExecutorFactory = packetHandlerExecutorFactory;
     }
@@ -104,7 +104,7 @@ public class NetworkServer extends AbstractServer {
 
     protected ChannelHandler getChannelHandler() {
         return new MinecraftChannelInitializer<>(channel -> {
-            PacketProtocol protocol = createPacketProtocol();
+            MinecraftProtocol protocol = createPacketProtocol();
 
             NetworkSession session = new ServerNetworkSession(channel.remoteAddress(), protocol, NetworkServer.this, packetHandlerExecutorFactory.get());
             session.getPacketProtocol().newServerSession(NetworkServer.this, session);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ClientNetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ClientNetworkSession.java
@@ -15,7 +15,7 @@ import org.geysermc.mcprotocollib.network.ProxyInfo;
 import org.geysermc.mcprotocollib.network.helper.NettyHelper;
 import org.geysermc.mcprotocollib.network.helper.TransportHelper;
 import org.geysermc.mcprotocollib.network.netty.MinecraftChannelInitializer;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.SocketAddress;
 import java.util.concurrent.CompletableFuture;
@@ -37,7 +37,7 @@ public class ClientNetworkSession extends NetworkSession implements ClientSessio
 
     public ClientNetworkSession(
         @NonNull SocketAddress remoteAddress,
-        @NonNull PacketProtocol protocol,
+        @NonNull MinecraftProtocol protocol,
         @NonNull Executor packetHandlerExecutor,
         @Nullable SocketAddress bindAddress,
         @Nullable ProxyInfo proxy
@@ -104,7 +104,7 @@ public class ClientNetworkSession extends NetworkSession implements ClientSessio
 
     protected ChannelHandler getChannelHandler() {
         return new MinecraftChannelInitializer<>(channel -> {
-            PacketProtocol protocol = getPacketProtocol();
+            MinecraftProtocol protocol = getPacketProtocol();
             protocol.newClientSession(ClientNetworkSession.this);
 
             return ClientNetworkSession.this;

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ClientNetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ClientNetworkSession.java
@@ -67,7 +67,7 @@ public class ClientNetworkSession extends NetworkSession implements ClientSessio
         CompletableFuture<Void> handleFuture = new CompletableFuture<>();
         bootstrap.connect().addListener((futureListener) -> {
             if (!futureListener.isSuccess()) {
-                exceptionCaught(null, futureListener.cause());
+                this.disconnect(this.getGenericDisconnectMessage(futureListener.cause()), futureListener.cause());
             }
 
             handleFuture.complete(null);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
@@ -19,7 +19,7 @@ import org.geysermc.mcprotocollib.network.event.session.PacketSendingEvent;
 import org.geysermc.mcprotocollib.network.event.session.SessionEvent;
 import org.geysermc.mcprotocollib.network.event.session.SessionListener;
 import org.geysermc.mcprotocollib.network.packet.Packet;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +37,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
     private static final Logger log = LoggerFactory.getLogger(NetworkSession.class);
 
     protected final SocketAddress remoteAddress;
-    protected final PacketProtocol protocol;
+    protected final MinecraftProtocol protocol;
     protected final Executor packetHandlerExecutor;
 
     private final Map<String, Object> flags = new HashMap<>();
@@ -46,7 +46,11 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
     private Channel channel;
     protected boolean disconnected = false;
 
-    public NetworkSession(SocketAddress remoteAddress, PacketProtocol protocol, Executor packetHandlerExecutor) {
+    public NetworkSession(
+        @NonNull SocketAddress remoteAddress,
+        @NonNull MinecraftProtocol protocol,
+        @NonNull Executor packetHandlerExecutor
+    ) {
         this.remoteAddress = remoteAddress;
         this.protocol = protocol;
         this.packetHandlerExecutor = packetHandlerExecutor;
@@ -63,7 +67,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
     }
 
     @Override
-    public PacketProtocol getPacketProtocol() {
+    public MinecraftProtocol getPacketProtocol() {
         return this.protocol;
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/NetworkSession.java
@@ -127,7 +127,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
                 event.call(listener);
             }
         } catch (Throwable t) {
-            exceptionCaught(null, t);
+            this.disconnect(this.getGenericDisconnectMessage(t), t);
         }
     }
 
@@ -138,7 +138,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
                 listener.packetReceived(this, packet);
             }
         } catch (Throwable t) {
-            exceptionCaught(null, t);
+            this.disconnect(this.getGenericDisconnectMessage(t), t);
         }
     }
 
@@ -149,7 +149,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
                 listener.packetSent(this, packet);
             }
         } catch (Throwable t) {
-            exceptionCaught(null, t);
+            this.disconnect(this.getGenericDisconnectMessage(t), t);
         }
     }
 
@@ -175,7 +175,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
 
     @Override
     public boolean isConnected() {
-        return this.channel != null && this.channel.isOpen() && !this.disconnected;
+        return this.channel != null && this.channel.isOpen();
     }
 
     @Override
@@ -203,7 +203,7 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
 
                     callPacketSent(toSend);
                 } else {
-                    exceptionCaught(null, future.cause());
+                    this.disconnect(this.getGenericDisconnectMessage(future.cause()), future.cause());
                 }
             });
         }
@@ -267,10 +267,14 @@ public abstract class NetworkSession extends SimpleChannelInboundHandler<Packet>
         if (cause instanceof TimeoutException) {
             message = Component.translatable("disconnect.timeout");
         } else {
-            message = Component.translatable("disconnect.genericReason", Component.text("Internal Exception: " + cause));
+            message = this.getGenericDisconnectMessage(cause);
         }
 
         this.disconnect(message, cause);
+    }
+
+    protected Component getGenericDisconnectMessage(Throwable cause) {
+        return Component.translatable("disconnect.genericReason", Component.text("Internal Exception: " + cause));
     }
 
     @Override

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ServerNetworkSession.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/session/ServerNetworkSession.java
@@ -1,10 +1,11 @@
 package org.geysermc.mcprotocollib.network.session;
 
 import io.netty.channel.ChannelHandlerContext;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.geysermc.mcprotocollib.network.Flag;
 import org.geysermc.mcprotocollib.network.ServerSession;
-import org.geysermc.mcprotocollib.network.packet.PacketProtocol;
 import org.geysermc.mcprotocollib.network.server.NetworkServer;
+import org.geysermc.mcprotocollib.protocol.MinecraftProtocol;
 
 import java.net.SocketAddress;
 import java.util.HashMap;
@@ -15,7 +16,12 @@ import java.util.function.Supplier;
 public class ServerNetworkSession extends NetworkSession implements ServerSession {
     private final NetworkServer server;
 
-    public ServerNetworkSession(SocketAddress remoteAddress, PacketProtocol protocol, NetworkServer server, Executor packetHandlerExecutor) {
+    public ServerNetworkSession(
+        @NonNull SocketAddress remoteAddress,
+        @NonNull MinecraftProtocol protocol,
+        @NonNull NetworkServer server,
+        @NonNull Executor packetHandlerExecutor
+    ) {
         super(remoteAddress, protocol, packetHandlerExecutor);
         this.server = server;
     }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ClientListener.java
@@ -62,7 +62,7 @@ public class ClientListener extends SessionAdapter {
     @SneakyThrows
     @Override
     public void packetReceived(Session session, Packet packet) {
-        MinecraftProtocol protocol = (MinecraftProtocol) session.getPacketProtocol();
+        MinecraftProtocol protocol = session.getPacketProtocol();
         if (protocol.getInboundState() == ProtocolState.LOGIN) {
             if (packet instanceof ClientboundHelloPacket helloPacket) {
                 GameProfile profile = session.getFlag(MinecraftConstants.PROFILE_KEY);
@@ -184,7 +184,7 @@ public class ClientListener extends SessionAdapter {
     @Override
     public void connected(ConnectedEvent event) {
         Session session = event.getSession();
-        MinecraftProtocol protocol = (MinecraftProtocol) session.getPacketProtocol();
+        MinecraftProtocol protocol = session.getPacketProtocol();
         ClientIntentionPacket intention = new ClientIntentionPacket(
             protocol.getCodec().getProtocolVersion(),
             session.getFlagSupplied(MinecraftConstants.CLIENT_HOST, () -> ((InetSocketAddress) session.getRemoteAddress()).getHostString()),

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -28,16 +28,16 @@ import org.geysermc.mcprotocollib.protocol.packet.configuration.clientbound.Clie
 import org.geysermc.mcprotocollib.protocol.packet.configuration.serverbound.ServerboundFinishConfigurationPacket;
 import org.geysermc.mcprotocollib.protocol.packet.handshake.serverbound.ClientIntentionPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ingame.serverbound.ServerboundConfigurationAcknowledgedPacket;
-import org.geysermc.mcprotocollib.protocol.packet.login.clientbound.ClientboundLoginFinishedPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.clientbound.ClientboundHelloPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.clientbound.ClientboundLoginCompressionPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.clientbound.ClientboundLoginDisconnectPacket;
+import org.geysermc.mcprotocollib.protocol.packet.login.clientbound.ClientboundLoginFinishedPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.serverbound.ServerboundHelloPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.serverbound.ServerboundKeyPacket;
 import org.geysermc.mcprotocollib.protocol.packet.login.serverbound.ServerboundLoginAcknowledgedPacket;
 import org.geysermc.mcprotocollib.protocol.packet.ping.clientbound.ClientboundPongResponsePacket;
-import org.geysermc.mcprotocollib.protocol.packet.status.clientbound.ClientboundStatusResponsePacket;
 import org.geysermc.mcprotocollib.protocol.packet.ping.serverbound.ServerboundPingRequestPacket;
+import org.geysermc.mcprotocollib.protocol.packet.status.clientbound.ClientboundStatusResponsePacket;
 import org.geysermc.mcprotocollib.protocol.packet.status.serverbound.ServerboundStatusRequestPacket;
 
 import javax.crypto.SecretKey;
@@ -95,7 +95,7 @@ public class ServerListener extends SessionAdapter {
 
     @Override
     public void packetReceived(Session session, Packet packet) {
-        MinecraftProtocol protocol = (MinecraftProtocol) session.getPacketProtocol();
+        MinecraftProtocol protocol = session.getPacketProtocol();
         if (protocol.getInboundState() == ProtocolState.HANDSHAKE) {
             if (packet instanceof ClientIntentionPacket intentionPacket) {
                 switch (intentionPacket.getIntent()) {
@@ -231,7 +231,7 @@ public class ServerListener extends SessionAdapter {
     @Override
     public void disconnecting(DisconnectingEvent event) {
         Session session = event.getSession();
-        MinecraftProtocol protocol = (MinecraftProtocol) session.getPacketProtocol();
+        MinecraftProtocol protocol = session.getPacketProtocol();
         if (protocol.getOutboundState() == ProtocolState.LOGIN) {
             session.send(new ClientboundLoginDisconnectPacket(event.getReason()));
         } else if (protocol.getOutboundState() == ProtocolState.GAME) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/MetadataTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/entity/metadata/MetadataTypes.java
@@ -26,7 +26,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 @Getter
-public class MetadataTypes<T> {
+public class MetadataTypes {
     private static final List<MetadataType<?>> VALUES = new ArrayList<>();
 
     public static final ByteMetadataType BYTE = register(id -> new ByteMetadataType(id, ByteBuf::readByte, ByteBuf::writeByte, ByteEntityMetadata::new));

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentTypes.java
@@ -19,7 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Getter
-public class DataComponentTypes<T> {
+public class DataComponentTypes {
     private static final List<DataComponentType<?>> VALUES = new ArrayList<>();
 
     public static final DataComponentType<NbtMap> CUSTOM_DATA = register(id -> new DataComponentType<>(id, "custom_data", MinecraftTypes::readCompoundTag, MinecraftTypes::writeAnyTag, ObjectDataComponent::new));


### PR DESCRIPTION
Fixes a race condition where packets would be sent while the channel was not open. Also allows disconnecting players with a message while they are not connected yet. Also does a few smaller refactors.