### PR TITLE
Correct validation logic for click-packet

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/packet/ingame/serverbound/inventory/ServerboundContainerClickPacket.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/packet/ingame/serverbound/inventory/ServerboundContainerClickPacket.java
@@ -45,7 +45,7 @@ public class ServerboundContainerClickPacket implements MinecraftPacket {
                                            @NonNull ContainerActionType action, @NonNull ContainerAction param,
                                            @Nullable ItemStack carriedItem, @NonNull Int2ObjectMap<@Nullable ItemStack> changedSlots) {
         if ((param == DropItemAction.LEFT_CLICK_OUTSIDE_NOT_HOLDING || param == DropItemAction.RIGHT_CLICK_OUTSIDE_NOT_HOLDING)
-                && slot != -CLICK_OUTSIDE_NOT_HOLDING_SLOT) {
+                && slot != CLICK_OUTSIDE_NOT_HOLDING_SLOT) {
             throw new IllegalArgumentException("Slot must be " + CLICK_OUTSIDE_NOT_HOLDING_SLOT
                     + " with param LEFT_CLICK_OUTSIDE_NOT_HOLDING or RIGHT_CLICK_OUTSIDE_NOT_HOLDING");
         }


### PR DESCRIPTION
fix: correct sign for CLICK_OUTSIDE_NOT_HOLDING_SLOT in validation

The CLICK_OUTSIDE_NOT_HOLDING_SLOT constant was incorrectly used without a minus sign, causing valid slots to be rejected during validation. This fix ensures the correct value (-999) is used, allowing proper validation.