### PR TITLE
Data components map improvements

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponentTypes.java
@@ -181,6 +181,10 @@ public class DataComponentTypes {
         return VALUES.get(id);
     }
 
+    public static DataComponentType<?> fromKey(Key key) {
+        return VALUES.stream().filter(component -> component.getKey().equals(key)).findFirst().orElse(null);
+    }
+
     public static int size() {
         return VALUES.size();
     }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponents.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/item/component/DataComponents.java
@@ -2,12 +2,24 @@ package org.geysermc.mcprotocollib.protocol.data.game.item.component;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.NonNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * Wrapper around a map of data components and their respective values.
+ *
+ * <p>This map can either be a complete data component map, or a data component patch to another map. The meaning of {@code null} values in the map depends on if the map
+ * is a patch or full map. If the map:</p>
+ *
+ * <ul>
+ *     <li>Is a full map, {@code null} means an absence of the component in the map. {@link DataComponents#put(DataComponentType, Object)} should not be used with {@code null} values, rather {@link DataComponents#remove(DataComponentType)} should be used.</li>
+ *     <li>Is a patch, {@code null} can mean an absence of the component in the patch, or that the component should be removed from a map the patch is applied to. Use {@link DataComponents#contains(DataComponentType)}, which returns {@code true} for the latter, to check which is the case.</li>
+ * </ul>
+ *
+ * <p>Make sure to initialise this class with a map that accepts null values if representing a patch.</p>
+ */
 @Data
 @AllArgsConstructor
 public class DataComponents {
@@ -25,14 +37,29 @@ public class DataComponents {
         return value != null ? value : def;
     }
 
-    public <T> void put(DataComponentType<T> type, @NonNull T value) {
-        if (type instanceof IntComponentType intType) {
+    /**
+     * @param value should only be {@code null } if this map is a patch to another map and specifying the removal of the specific component.
+     */
+    public <T> void put(DataComponentType<T> type, @Nullable T value) {
+        if (value == null) {
+            dataComponents.put(type, null);
+        } else if (type instanceof IntComponentType intType) {
             dataComponents.put(intType, intType.primitiveFactory.createPrimitive(intType, (Integer) value));
         } else if (type instanceof BooleanComponentType boolType) {
             dataComponents.put(boolType, boolType.primitiveFactory.createPrimitive(boolType, (Boolean) value));
         } else {
             dataComponents.put(type, type.dataComponentFactory.create(type, value));
         }
+    }
+
+    public boolean contains(DataComponentType<?> component) {
+        return dataComponents.containsKey(component);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <T> @Nullable T remove(DataComponentType<T> component) {
+        DataComponent<T, ?> removed = (DataComponent<T, ?>) dataComponents.remove(component);
+        return removed == null ? null : removed.getValue();
     }
 
     public DataComponents clone() {


### PR DESCRIPTION
This PR makes a couple of small improvements to the `DataComponents` class:

- Added `contains(DataComponentType<?>)` and `remove(DataComponentType<T>)` methods.
- Make `put(DataComponentType<T>, T)` allow null values.
- Add Javadoc to make usage of null values clear.

In the future, an additional, separate class should probably be created for data component patches.

This PR also makes a small change to `DataComponentTypes`: a `fromKey(Key)` method was added.