### PR TITLE
Migrate to io_uring that's now part of netty-all

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,7 @@ cloudburstnbt = "3.0.0.Final"
 slf4j = "2.0.9"
 math = "2.0"
 fastutil-maps = "8.5.3"
-netty = "4.1.103.Final"
-netty-io_uring = "0.0.24.Final"
+netty = "4.2.1.Final"
 gson = "2.11.0"
 minecraftauth = "4.1.1"
 checkerframework = "3.42.0"
@@ -37,7 +36,6 @@ fastutil-int2object-maps = { module = "com.nukkitx.fastutil:fastutil-int-object-
 fastutil-int2int-maps = { module = "com.nukkitx.fastutil:fastutil-int-int-maps", version.ref = "fastutil-maps" }
 
 netty-all = { module = "io.netty:netty-all", version.ref = "netty" }
-netty-incubator-transport-native-io_uring = { module = "io.netty.incubator:netty-incubator-transport-native-io_uring", version.ref = "netty-io_uring" }
 
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 
@@ -57,4 +55,4 @@ lombok = { module = "io.freefair.gradle:lombok-plugin", version.ref = "lombok-pl
 adventure = ["adventure-text-serializer-gson", "adventure-text-serializer-json-legacy-impl"]
 math = ["math-api", "math-immutable"]
 fastutil = ["fastutil-object2int-maps", "fastutil-int2object-maps", "fastutil-int2int-maps"]
-netty = ["netty-all", "netty-incubator-transport-native-io_uring"]
+netty = ["netty-all"]

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/helper/TransportHelper.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/helper/TransportHelper.java
@@ -48,7 +48,7 @@ public class TransportHelper {
     }
 
     private static TransportType determineTransportMethod() {
-        if (isClassAvailable("io.netty.incubator.channel.uring.IOUring") && IOUring.isAvailable()) {
+        if (isClassAvailable("io.netty.channel.uring.IOUring") && IOUring.isAvailable()) {
             return new TransportType(
                     TransportMethod.IO_URING,
                     IOUringServerSocketChannel.class,

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/network/helper/TransportHelper.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/network/helper/TransportHelper.java
@@ -19,11 +19,11 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioDatagramChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
-import io.netty.incubator.channel.uring.IOUring;
-import io.netty.incubator.channel.uring.IOUringDatagramChannel;
-import io.netty.incubator.channel.uring.IOUringEventLoopGroup;
-import io.netty.incubator.channel.uring.IOUringServerSocketChannel;
-import io.netty.incubator.channel.uring.IOUringSocketChannel;
+import io.netty.channel.uring.IOUring;
+import io.netty.channel.uring.IOUringDatagramChannel;
+import io.netty.channel.uring.IOUringEventLoopGroup;
+import io.netty.channel.uring.IOUringServerSocketChannel;
+import io.netty.channel.uring.IOUringSocketChannel;
 
 import java.util.concurrent.ThreadFactory;
 import java.util.function.Function;


### PR DESCRIPTION
Very recently the io_uring netty transport has left incubator state, the io_uring transport is now part of the main netty codebase and is distributed using the netty-all project.