### PR TITLE
Properly calculate global BPE and add initial value for data palettes

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
@@ -1332,7 +1332,7 @@ public class MinecraftTypes {
         }
     }
 
-    public static DataPalette readDataPalette(ByteBuf buf, PaletteType paletteType) {
+    public static DataPalette readDataPalette(ByteBuf buf, PaletteType paletteType, int registrySize) {
         int bitsPerEntry = buf.readByte() & 0xFF;
         Palette palette = MinecraftTypes.readPalette(buf, paletteType, bitsPerEntry);
         BitStorage storage;
@@ -1343,15 +1343,7 @@ public class MinecraftTypes {
             MinecraftTypes.readFixedSizeLongArray(buf, storage.getData());
         }
 
-        return new DataPalette(palette, storage, paletteType);
-    }
-
-    /**
-     * @deprecated globalPaletteBits is no longer in use, use {@link #readDataPalette(ByteBuf, PaletteType)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public static DataPalette readDataPalette(ByteBuf buf, PaletteType paletteType, int globalPaletteBits) {
-        return MinecraftTypes.readDataPalette(buf, paletteType);
+        return DataPalette.create(palette, storage, paletteType, registrySize);
     }
 
     public static void writeDataPalette(ByteBuf buf, DataPalette palette) {
@@ -1388,20 +1380,12 @@ public class MinecraftTypes {
         }
     }
 
-    public static ChunkSection readChunkSection(ByteBuf buf) {
+    public static ChunkSection readChunkSection(ByteBuf buf, int blockStateRegistrySize, int biomeRegistrySize) {
         int blockCount = buf.readShort();
 
-        DataPalette chunkPalette = MinecraftTypes.readDataPalette(buf, PaletteType.CHUNK);
-        DataPalette biomePalette = MinecraftTypes.readDataPalette(buf, PaletteType.BIOME);
+        DataPalette chunkPalette = MinecraftTypes.readDataPalette(buf, PaletteType.CHUNK, blockStateRegistrySize);
+        DataPalette biomePalette = MinecraftTypes.readDataPalette(buf, PaletteType.BIOME, biomeRegistrySize);
         return new ChunkSection(blockCount, chunkPalette, biomePalette);
-    }
-
-    /**
-     * @deprecated globalBiomePaletteBits is no longer in use, use {@link #readChunkSection(ByteBuf)} instead.
-     */
-    @Deprecated(forRemoval = true)
-    public static ChunkSection readChunkSection(ByteBuf buf, int globalBiomePaletteBits) {
-        return MinecraftTypes.readChunkSection(buf);
     }
 
     public static void writeChunkSection(ByteBuf buf, ChunkSection section) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
@@ -1383,14 +1383,14 @@ public class MinecraftTypes {
     public static ChunkSection readChunkSection(ByteBuf buf, int blockStateRegistrySize, int biomeRegistrySize) {
         int blockCount = buf.readShort();
 
-        DataPalette chunkPalette = MinecraftTypes.readDataPalette(buf, PaletteType.CHUNK, blockStateRegistrySize);
+        DataPalette blockStatePalette = MinecraftTypes.readDataPalette(buf, PaletteType.BLOCK_STATE, blockStateRegistrySize);
         DataPalette biomePalette = MinecraftTypes.readDataPalette(buf, PaletteType.BIOME, biomeRegistrySize);
-        return new ChunkSection(blockCount, chunkPalette, biomePalette);
+        return new ChunkSection(blockCount, blockStatePalette, biomePalette);
     }
 
     public static void writeChunkSection(ByteBuf buf, ChunkSection section) {
         buf.writeShort(section.getBlockCount());
-        MinecraftTypes.writeDataPalette(buf, section.getChunkData());
+        MinecraftTypes.writeDataPalette(buf, section.getBlockData());
         MinecraftTypes.writeDataPalette(buf, section.getBiomeData());
     }
 

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/ChunkSection.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/ChunkSection.java
@@ -21,8 +21,8 @@ public class ChunkSection {
     @Getter
     private @NonNull DataPalette biomeData;
 
-    public ChunkSection() {
-        this(0, DataPalette.createForChunk(), DataPalette.createForBiome());
+    public ChunkSection(int blockStateRegistrySize, int biomeRegistrySize) {
+        this(0, DataPalette.createForChunk(blockStateRegistrySize), DataPalette.createForBiome(biomeRegistrySize));
     }
 
     public ChunkSection(ChunkSection original) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/ChunkSection.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/ChunkSection.java
@@ -21,8 +21,8 @@ public class ChunkSection {
     @Getter
     private @NonNull DataPalette biomeData;
 
-    public ChunkSection(int blockStateRegistrySize, int biomeRegistrySize) {
-        this(0, DataPalette.createForChunk(blockStateRegistrySize), DataPalette.createForBiome(biomeRegistrySize));
+    public ChunkSection(int initialBlockState, int blockStateRegistrySize, int initialBiome, int biomeRegistrySize) {
+        this(0, DataPalette.createForChunk(initialBlockState, blockStateRegistrySize), DataPalette.createForBiome(initialBiome, biomeRegistrySize));
     }
 
     public ChunkSection(ChunkSection original) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/ChunkSection.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/ChunkSection.java
@@ -17,24 +17,24 @@ public class ChunkSection {
     private static final int AIR = 0;
 
     private int blockCount;
-    private @NonNull DataPalette chunkData;
+    private @NonNull DataPalette blockData;
     @Getter
     private @NonNull DataPalette biomeData;
 
     public ChunkSection(int initialBlockState, int blockStateRegistrySize, int initialBiome, int biomeRegistrySize) {
-        this(0, DataPalette.createForChunk(initialBlockState, blockStateRegistrySize), DataPalette.createForBiome(initialBiome, biomeRegistrySize));
+        this(0, DataPalette.createForBlockState(initialBlockState, blockStateRegistrySize), DataPalette.createForBiome(initialBiome, biomeRegistrySize));
     }
 
     public ChunkSection(ChunkSection original) {
-        this(original.blockCount, new DataPalette(original.chunkData), new DataPalette(original.biomeData));
+        this(original.blockCount, new DataPalette(original.blockData), new DataPalette(original.biomeData));
     }
 
     public int getBlock(int x, int y, int z) {
-        return this.chunkData.get(x, y, z);
+        return this.blockData.get(x, y, z);
     }
 
     public void setBlock(int x, int y, int z, int state) {
-        int curr = this.chunkData.set(x, y, z, state);
+        int curr = this.blockData.set(x, y, z, state);
         if (state != AIR && curr == AIR) {
             this.blockCount++;
         } else if (state == AIR && curr != AIR) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/DataPalette.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/DataPalette.java
@@ -33,8 +33,8 @@ public class DataPalette {
         this(original.palette.copy(), original.storage == null ? null : new BitStorage(original.storage), original.paletteType, original.globalPaletteBitsPerEntry);
     }
 
-    public static DataPalette createForChunk(int initialState, int blockStateRegistrySize) {
-        return createEmpty(PaletteType.CHUNK, initialState, blockStateRegistrySize);
+    public static DataPalette createForBlockState(int initialState, int blockStateRegistrySize) {
+        return createEmpty(PaletteType.BLOCK_STATE, initialState, blockStateRegistrySize);
     }
 
     public static DataPalette createForBiome(int initialBiome, int biomeRegistrySize) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/DataPalette.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/DataPalette.java
@@ -33,17 +33,16 @@ public class DataPalette {
         this(original.palette.copy(), original.storage == null ? null : new BitStorage(original.storage), original.paletteType, original.globalPaletteBitsPerEntry);
     }
 
-    public static DataPalette createForChunk(int blockStateRegistrySize) {
-        return createEmpty(PaletteType.CHUNK, blockStateRegistrySize);
+    public static DataPalette createForChunk(int initialState, int blockStateRegistrySize) {
+        return createEmpty(PaletteType.CHUNK, initialState, blockStateRegistrySize);
     }
 
-    public static DataPalette createForBiome(int biomeRegistrySize) {
-        return createEmpty(PaletteType.BIOME, biomeRegistrySize);
+    public static DataPalette createForBiome(int initialBiome, int biomeRegistrySize) {
+        return createEmpty(PaletteType.BIOME, initialBiome, biomeRegistrySize);
     }
 
-    public static DataPalette createEmpty(PaletteType paletteType, int registrySize) {
-        return create(new ListPalette(paletteType.getMinBitsPerEntry()),
-                new BitStorage(paletteType.getMinBitsPerEntry(), paletteType.getStorageSize()), paletteType, registrySize);
+    public static DataPalette createEmpty(PaletteType paletteType, int initial, int registrySize) {
+        return create(new SingletonPalette(initial), null, paletteType, registrySize);
     }
 
     public static DataPalette create(@NonNull Palette palette, BitStorage storage, PaletteType paletteType, int registrySize) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/palette/PaletteType.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/data/game/chunk/palette/PaletteType.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 @Getter
 public enum PaletteType {
     BIOME(1, 3, 64),
-    CHUNK(4, 8, 4096);
+    BLOCK_STATE(4, 8, 4096);
 
     private final int minBitsPerEntry;
     private final int maxBitsPerEntry;

--- a/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/data/ChunkTest.java
+++ b/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/data/ChunkTest.java
@@ -35,9 +35,9 @@ public class ChunkTest {
         chunkSectionsToTest.add(section);
 
         SingletonPalette singletonPalette = new SingletonPalette(20);
-        DataPalette dataPalette = DataPalette.create(singletonPalette, null, PaletteType.CHUNK, BLOCK_STATE_REGISTRY_SIZE);
+        DataPalette blockPalette = DataPalette.create(singletonPalette, null, PaletteType.BLOCK_STATE, BLOCK_STATE_REGISTRY_SIZE);
         DataPalette biomePalette = DataPalette.create(singletonPalette, null, PaletteType.BIOME, BIOME_REGISTRY_SIZE);
-        section = new ChunkSection(4096, dataPalette, biomePalette);
+        section = new ChunkSection(4096, blockPalette, biomePalette);
         chunkSectionsToTest.add(section);
     }
 

--- a/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/data/ChunkTest.java
+++ b/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/data/ChunkTest.java
@@ -28,9 +28,9 @@ public class ChunkTest {
 
     @BeforeEach
     public void setup() {
-        chunkSectionsToTest.add(new ChunkSection(BLOCK_STATE_REGISTRY_SIZE, BIOME_REGISTRY_SIZE));
+        chunkSectionsToTest.add(new ChunkSection(420, BLOCK_STATE_REGISTRY_SIZE, 42, BIOME_REGISTRY_SIZE));
 
-        ChunkSection section = new ChunkSection(BLOCK_STATE_REGISTRY_SIZE, BIOME_REGISTRY_SIZE);
+        ChunkSection section = new ChunkSection(20, BLOCK_STATE_REGISTRY_SIZE, 35, BIOME_REGISTRY_SIZE);
         section.setBlock(0, 0, 0, 10);
         chunkSectionsToTest.add(section);
 

--- a/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/data/ChunkTest.java
+++ b/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/data/ChunkTest.java
@@ -19,20 +19,24 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ChunkTest {
+    // Arbitrary registry size values
+    private static final int BLOCK_STATE_REGISTRY_SIZE = 1000;
+    private static final int BIOME_REGISTRY_SIZE = 100;
+
     private static final Logger log = LoggerFactory.getLogger(ChunkTest.class);
     private final List<ChunkSection> chunkSectionsToTest = new ArrayList<>();
 
     @BeforeEach
     public void setup() {
-        chunkSectionsToTest.add(new ChunkSection());
+        chunkSectionsToTest.add(new ChunkSection(BLOCK_STATE_REGISTRY_SIZE, BIOME_REGISTRY_SIZE));
 
-        ChunkSection section = new ChunkSection();
+        ChunkSection section = new ChunkSection(BLOCK_STATE_REGISTRY_SIZE, BIOME_REGISTRY_SIZE);
         section.setBlock(0, 0, 0, 10);
         chunkSectionsToTest.add(section);
 
         SingletonPalette singletonPalette = new SingletonPalette(20);
-        DataPalette dataPalette = new DataPalette(singletonPalette, null, PaletteType.CHUNK);
-        DataPalette biomePalette = new DataPalette(singletonPalette, null, PaletteType.BIOME);
+        DataPalette dataPalette = DataPalette.create(singletonPalette, null, PaletteType.CHUNK, BLOCK_STATE_REGISTRY_SIZE);
+        DataPalette biomePalette = DataPalette.create(singletonPalette, null, PaletteType.BIOME, BIOME_REGISTRY_SIZE);
         section = new ChunkSection(4096, dataPalette, biomePalette);
         chunkSectionsToTest.add(section);
     }
@@ -44,7 +48,7 @@ public class ChunkTest {
             MinecraftTypes.writeChunkSection(buf, section);
             ChunkSection decoded;
             try {
-                decoded = MinecraftTypes.readChunkSection(buf);
+                decoded = MinecraftTypes.readChunkSection(buf, BLOCK_STATE_REGISTRY_SIZE, BIOME_REGISTRY_SIZE);
             } catch (Exception e) {
                 log.error(section.toString(), e);
                 throw e;


### PR DESCRIPTION
This PR re-introduces custom global BPE (bits-per-entry) values for data palettes, however, instead of passing these directly, library users pass the size of the applying registry (block state or biome), and MCPL calculates the global BPE value necessary to store all of the values of that registry.

When creating an empty data palette, MCPL now uses a singleton palette instead of a list palette. This saves a bit of space. Library users also have to specify the initial value of the data palette, instead of this defaulting to whatever state is first set in the palette.

`PaletteType.CHUNK` has also been renamed to `PaletteType.BLOCK_STATE` for clarity. Related variables and parameters have also been renamed.