### PR TITLE
Refactor: Code clarity improvements (Extract Method, Explaining Variable, Rename)

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/auth/SessionService.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/auth/SessionService.java
@@ -32,7 +32,7 @@ public class SessionService {
     /**
      * Calculates the server ID from a base string, public key, and secret key.
      *
-     * @param base Base server ID to use.
+     * @param base      Base server ID to use.
      * @param publicKey Public key to use.
      * @param secretKey Secret key to use.
      * @return The calculated server ID.
@@ -53,9 +53,9 @@ public class SessionService {
     /**
      * Joins a server.
      *
-     * @param profile Profile to join the server with.
+     * @param profile             Profile to join the server with.
      * @param authenticationToken Authentication token to join the server with.
-     * @param serverId ID of the server to join.
+     * @param serverId            ID of the server to join.
      * @throws IOException If an error occurs while making the request.
      */
     public void joinServer(GameProfile profile, String authenticationToken, String serverId) throws IOException {
@@ -64,18 +64,21 @@ public class SessionService {
     }
 
     /**
-     * Gets the profile of the given user if they are currently logged in to the given server.
+     * Gets the profile of the given user if they are currently logged in to the
+     * given server.
      *
-     * @param name Name of the user to get the profile of.
+     * @param name     Name of the user to get the profile of.
      * @param serverId ID of the server to check if they're logged in to.
-     * @return The profile of the given user, or null if they are not logged in to the given server.
+     * @return The profile of the given user, or null if they are not logged in to
+     *         the given server.
      * @throws IOException If an error occurs while making the request.
      */
     public GameProfile getProfileByServer(String name, String serverId) throws IOException {
+        URI hasJoinedUri = URI.create(String.format(HAS_JOINED_ENDPOINT,
+                URLEncoder.encode(name, StandardCharsets.UTF_8),
+                URLEncoder.encode(serverId, StandardCharsets.UTF_8)));
         HasJoinedResponse response = HTTPUtils.makeRequest(this.getProxy(),
-                URI.create(String.format(HAS_JOINED_ENDPOINT,
-                        URLEncoder.encode(name, StandardCharsets.UTF_8),
-                        URLEncoder.encode(serverId, StandardCharsets.UTF_8))),
+                hasJoinedUri,
                 null, HasJoinedResponse.class);
         if (response != null && response.id != null) {
             GameProfile result = new GameProfile(response.id, name);
@@ -97,9 +100,12 @@ public class SessionService {
             return;
         }
 
-        MinecraftProfileResponse response = HTTPUtils.makeRequest(this.getProxy(), URI.create(String.format(PROFILE_ENDPOINT, UUIDUtils.convertToNoDashes(profile.getId()))), null, MinecraftProfileResponse.class);
+        URI profileUri = URI.create(String.format(PROFILE_ENDPOINT, UUIDUtils.convertToNoDashes(profile.getId())));
+        MinecraftProfileResponse response = HTTPUtils.makeRequest(this.getProxy(), profileUri, null,
+                MinecraftProfileResponse.class);
         if (response == null) {
-            throw new IllegalStateException("Couldn't fetch profile properties for " + profile + " as the profile does not exist.");
+            throw new IllegalStateException(
+                    "Couldn't fetch profile properties for " + profile + " as the profile does not exist.");
         }
 
         profile.setProperties(response.properties);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/auth/SessionService.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/auth/SessionService.java
@@ -32,7 +32,7 @@ public class SessionService {
     /**
      * Calculates the server ID from a base string, public key, and secret key.
      *
-     * @param base      Base server ID to use.
+     * @param base Base server ID to use.
      * @param publicKey Public key to use.
      * @param secretKey Secret key to use.
      * @return The calculated server ID.
@@ -53,9 +53,9 @@ public class SessionService {
     /**
      * Joins a server.
      *
-     * @param profile             Profile to join the server with.
+     * @param profile Profile to join the server with.
      * @param authenticationToken Authentication token to join the server with.
-     * @param serverId            ID of the server to join.
+     * @param serverId ID of the server to join.
      * @throws IOException If an error occurs while making the request.
      */
     public void joinServer(GameProfile profile, String authenticationToken, String serverId) throws IOException {
@@ -64,22 +64,16 @@ public class SessionService {
     }
 
     /**
-     * Gets the profile of the given user if they are currently logged in to the
-     * given server.
+     * Gets the profile of the given user if they are currently logged in to the given server.
      *
-     * @param name     Name of the user to get the profile of.
+     * @param name Name of the user to get the profile of.
      * @param serverId ID of the server to check if they're logged in to.
-     * @return The profile of the given user, or null if they are not logged in to
-     *         the given server.
+     * @return The profile of the given user, or null if they are not logged in to the given server.
      * @throws IOException If an error occurs while making the request.
      */
     public GameProfile getProfileByServer(String name, String serverId) throws IOException {
-        URI hasJoinedUri = URI.create(String.format(HAS_JOINED_ENDPOINT,
-                URLEncoder.encode(name, StandardCharsets.UTF_8),
-                URLEncoder.encode(serverId, StandardCharsets.UTF_8)));
-        HasJoinedResponse response = HTTPUtils.makeRequest(this.getProxy(),
-                hasJoinedUri,
-                null, HasJoinedResponse.class);
+        URI hasJoinedUri = URI.create(String.format(HAS_JOINED_ENDPOINT, URLEncoder.encode(name, StandardCharsets.UTF_8), URLEncoder.encode(serverId, StandardCharsets.UTF_8)));
+        HasJoinedResponse response = HTTPUtils.makeRequest(this.getProxy(), hasJoinedUri, null, HasJoinedResponse.class);
         if (response != null && response.id != null) {
             GameProfile result = new GameProfile(response.id, name);
             result.setProperties(response.properties);
@@ -101,11 +95,9 @@ public class SessionService {
         }
 
         URI profileUri = URI.create(String.format(PROFILE_ENDPOINT, UUIDUtils.convertToNoDashes(profile.getId())));
-        MinecraftProfileResponse response = HTTPUtils.makeRequest(this.getProxy(), profileUri, null,
-                MinecraftProfileResponse.class);
+        MinecraftProfileResponse response = HTTPUtils.makeRequest(this.getProxy(), profileUri, null, MinecraftProfileResponse.class);
         if (response == null) {
-            throw new IllegalStateException(
-                    "Couldn't fetch profile properties for " + profile + " as the profile does not exist.");
+            throw new IllegalStateException("Couldn't fetch profile properties for " + profile + " as the profile does not exist.");
         }
 
         profile.setProperties(response.properties);

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -116,8 +116,7 @@ public class ServerListener extends SessionAdapter {
                 }
                 case TRANSFER -> beginLogin(session, protocol, intentionPacket, true);
                 case LOGIN -> beginLogin(session, protocol, intentionPacket, false);
-                default -> throw new UnsupportedOperationException(
-                        "Invalid client intent: " + intentionPacket.getIntent());
+                default -> throw new UnsupportedOperationException("Invalid client intent: " + intentionPacket.getIntent());
             }
         }
     }
@@ -127,8 +126,7 @@ public class ServerListener extends SessionAdapter {
             this.username = helloPacket.getUsername();
 
             if (session.getFlag(MinecraftConstants.ENCRYPT_CONNECTION, true)) {
-                session.send(new ClientboundHelloPacket(SERVER_ID, KEY_PAIR.getPublic(), this.challenge,
-                        session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true)));
+                session.send(new ClientboundHelloPacket(SERVER_ID, KEY_PAIR.getPublic(), this.challenge, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true)));
             } else {
                 new Thread(() -> authenticate(session, false, null)).start();
             }
@@ -141,9 +139,7 @@ public class ServerListener extends SessionAdapter {
 
             SecretKey key = keyPacket.getSecretKey(privateKey);
             session.setEncryption(protocol.createEncryption(key));
-            new Thread(
-                    () -> authenticate(session, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true), key))
-                    .start();
+            new Thread(() -> authenticate(session, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true), key)).start();
         } else if (packet instanceof ServerboundLoginAcknowledgedPacket) {
             protocol.setOutboundState(ProtocolState.CONFIGURATION);
             session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
@@ -153,8 +149,7 @@ public class ServerListener extends SessionAdapter {
                 new Thread(() -> keepAlive(session)).start();
             }
 
-            // Credit ViaVersion:
-            // https://github.com/ViaVersion/ViaVersion/blob/dev/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
+            // Credit ViaVersion: https://github.com/ViaVersion/ViaVersion/blob/dev/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
             for (Map.Entry<String, Object> entry : networkCodec.entrySet()) {
                 @SuppressWarnings("PatternValidation")
                 NbtMap entryTag = (NbtMap) entry.getValue();
@@ -183,10 +178,10 @@ public class ServerListener extends SessionAdapter {
                 builder = $ -> new ServerStatusInfo(
                         Component.text("A Minecraft Server"),
                         new PlayerInfo(0, 20, new ArrayList<>()),
-                        new VersionInfo(protocol.getCodec().getMinecraftVersion(),
-                                protocol.getCodec().getProtocolVersion()),
+                        new VersionInfo(protocol.getCodec().getMinecraftVersion(), protocol.getCodec().getProtocolVersion()),
                         null,
-                        false);
+                        false
+                );
             }
 
             ServerStatusInfo info = builder.buildInfo(session);
@@ -200,12 +195,9 @@ public class ServerListener extends SessionAdapter {
         if (packet instanceof ServerboundKeepAlivePacket keepAlivePacket) {
             handleKeepAlive(session, keepAlivePacket);
         } else if (packet instanceof ServerboundConfigurationAcknowledgedPacket) {
-            // The developer who sends ClientboundStartConfigurationPacket needs to
-            // setOutboundState to CONFIGURATION
-            // after sending the packet. We can't do it in this class because it needs to be
-            // a method call right after it was sent.
-            // Using nettys event loop to change outgoing state may cause differences to
-            // vanilla.
+            // The developer who sends ClientboundStartConfigurationPacket needs to setOutboundState to CONFIGURATION
+            // after sending the packet. We can't do it in this class because it needs to be a method call right after it was sent.
+            // Using nettys event loop to change outgoing state may cause differences to vanilla.
             session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
             keepAliveState = new KeepAliveState();
         } else if (packet instanceof ServerboundPingRequestPacket pingRequestPacket) {
@@ -231,29 +223,24 @@ public class ServerListener extends SessionAdapter {
     private void handleKeepAlive(Session session, ServerboundKeepAlivePacket keepAlivePacket) {
         KeepAliveState currentKeepAliveState = this.keepAliveState;
         if (currentKeepAliveState != null) {
-            if (currentKeepAliveState.keepAlivePending
-                    && keepAlivePacket.getPingId() == currentKeepAliveState.keepAliveChallenge) {
+            if (currentKeepAliveState.keepAlivePending && keepAlivePacket.getPingId() == currentKeepAliveState.keepAliveChallenge) {
                 currentKeepAliveState.keepAlivePending = false;
-                session.setFlag(MinecraftConstants.PING_KEY,
-                        System.currentTimeMillis() - currentKeepAliveState.keepAliveTime);
+                session.setFlag(MinecraftConstants.PING_KEY, System.currentTimeMillis() - currentKeepAliveState.keepAliveTime);
             } else {
                 session.disconnect(Component.translatable("disconnect.timeout"));
             }
         }
     }
 
-    private void beginLogin(Session session, MinecraftProtocol protocol, ClientIntentionPacket packet,
-            boolean transferred) {
+    private void beginLogin(Session session, MinecraftProtocol protocol, ClientIntentionPacket packet, boolean transferred) {
         isTransfer = transferred;
         protocol.setOutboundState(ProtocolState.LOGIN);
         if (transferred && !session.getFlag(MinecraftConstants.ACCEPT_TRANSFERS_KEY)) {
             session.disconnect(Component.translatable("multiplayer.disconnect.transfers_disabled"));
         } else if (packet.getProtocolVersion() > protocol.getCodec().getProtocolVersion()) {
-            session.disconnect(Component.translatable("multiplayer.disconnect.incompatible",
-                    Component.text(protocol.getCodec().getMinecraftVersion())));
+            session.disconnect(Component.translatable("multiplayer.disconnect.incompatible", Component.text(protocol.getCodec().getMinecraftVersion())));
         } else if (packet.getProtocolVersion() < protocol.getCodec().getProtocolVersion()) {
-            session.disconnect(Component.translatable("multiplayer.disconnect.outdated_client",
-                    Component.text(protocol.getCodec().getMinecraftVersion())));
+            session.disconnect(Component.translatable("multiplayer.disconnect.outdated_client", Component.text(protocol.getCodec().getMinecraftVersion())));
         } else {
             session.switchInboundState(() -> protocol.setInboundState(ProtocolState.LOGIN));
         }
@@ -273,11 +260,9 @@ public class ServerListener extends SessionAdapter {
     private void authenticate(Session session, boolean shouldAuthenticate, SecretKey key) {
         GameProfile profile;
         if (shouldAuthenticate && key != null) {
-            SessionService sessionService = session.getFlag(MinecraftConstants.SESSION_SERVICE_KEY,
-                    new SessionService());
+            SessionService sessionService = session.getFlag(MinecraftConstants.SESSION_SERVICE_KEY, new SessionService());
             try {
-                profile = sessionService.getProfileByServer(username,
-                        SessionService.getServerId(SERVER_ID, KEY_PAIR.getPublic(), key));
+                profile = sessionService.getProfileByServer(username, SessionService.getServerId(SERVER_ID, KEY_PAIR.getPublic(), key));
             } catch (IOException e) {
                 session.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"), e);
                 return;
@@ -295,8 +280,7 @@ public class ServerListener extends SessionAdapter {
 
         int threshold = session.getFlag(MinecraftConstants.SERVER_COMPRESSION_THRESHOLD, DEFAULT_COMPRESSION_THRESHOLD);
         if (threshold >= 0) {
-            session.send(new ClientboundLoginCompressionPacket(threshold),
-                    () -> session.setCompression(new CompressionConfig(threshold, new ZlibCompression(), true)));
+            session.send(new ClientboundLoginCompressionPacket(threshold), () -> session.setCompression(new CompressionConfig(threshold, new ZlibCompression(), true)));
         }
 
         session.send(new ClientboundLoginFinishedPacket(profile));

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -280,7 +280,8 @@ public class ServerListener extends SessionAdapter {
 
         int threshold = session.getFlag(MinecraftConstants.SERVER_COMPRESSION_THRESHOLD, DEFAULT_COMPRESSION_THRESHOLD);
         if (threshold >= 0) {
-            session.send(new ClientboundLoginCompressionPacket(threshold), () -> session.setCompression(new CompressionConfig(threshold, new ZlibCompression(), true)));
+            session.send(new ClientboundLoginCompressionPacket(threshold), () ->
+                    session.setCompression(new CompressionConfig(threshold, new ZlibCompression(), true)));
         }
 
         session.send(new ClientboundLoginFinishedPacket(profile));

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -98,116 +98,132 @@ public class ServerListener extends SessionAdapter {
     @Override
     public void packetReceived(Session session, Packet packet) {
         MinecraftProtocol protocol = session.getPacketProtocol();
-        if (protocol.getInboundState() == ProtocolState.HANDSHAKE) {
-            if (packet instanceof ClientIntentionPacket intentionPacket) {
-                switch (intentionPacket.getIntent()) {
-                    case STATUS -> {
-                        protocol.setOutboundState(ProtocolState.STATUS);
-                        session.switchInboundState(() -> protocol.setInboundState(ProtocolState.STATUS));
-                    }
-                    case TRANSFER -> beginLogin(session, protocol, intentionPacket, true);
-                    case LOGIN -> beginLogin(session, protocol, intentionPacket, false);
-                    default -> throw new UnsupportedOperationException(
-                            "Invalid client intent: " + intentionPacket.getIntent());
+        switch (protocol.getInboundState()) {
+            case HANDSHAKE -> handleHandshakePacket(session, protocol, packet);
+            case LOGIN -> handleLoginPacket(session, protocol, packet);
+            case STATUS -> handleStatusPacket(session, protocol, packet);
+            case GAME -> handleGamePacket(session, protocol, packet);
+            case CONFIGURATION -> handleConfigurationPacket(session, protocol, packet);
+        }
+    }
+
+    private void handleHandshakePacket(Session session, MinecraftProtocol protocol, Packet packet) {
+        if (packet instanceof ClientIntentionPacket intentionPacket) {
+            switch (intentionPacket.getIntent()) {
+                case STATUS -> {
+                    protocol.setOutboundState(ProtocolState.STATUS);
+                    session.switchInboundState(() -> protocol.setInboundState(ProtocolState.STATUS));
                 }
+                case TRANSFER -> beginLogin(session, protocol, intentionPacket, true);
+                case LOGIN -> beginLogin(session, protocol, intentionPacket, false);
+                default -> throw new UnsupportedOperationException(
+                        "Invalid client intent: " + intentionPacket.getIntent());
             }
-        } else if (protocol.getInboundState() == ProtocolState.LOGIN) {
-            if (packet instanceof ServerboundHelloPacket helloPacket) {
-                this.username = helloPacket.getUsername();
+        }
+    }
 
-                if (session.getFlag(MinecraftConstants.ENCRYPT_CONNECTION, true)) {
-                    session.send(new ClientboundHelloPacket(SERVER_ID, KEY_PAIR.getPublic(), this.challenge,
-                            session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true)));
-                } else {
-                    new Thread(() -> authenticate(session, false, null)).start();
-                }
-            } else if (packet instanceof ServerboundKeyPacket keyPacket) {
-                PrivateKey privateKey = KEY_PAIR.getPrivate();
+    private void handleLoginPacket(Session session, MinecraftProtocol protocol, Packet packet) {
+        if (packet instanceof ServerboundHelloPacket helloPacket) {
+            this.username = helloPacket.getUsername();
 
-                if (!Arrays.equals(this.challenge, keyPacket.getEncryptedChallenge(privateKey))) {
-                    throw new IllegalStateException("Protocol error");
-                }
+            if (session.getFlag(MinecraftConstants.ENCRYPT_CONNECTION, true)) {
+                session.send(new ClientboundHelloPacket(SERVER_ID, KEY_PAIR.getPublic(), this.challenge,
+                        session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true)));
+            } else {
+                new Thread(() -> authenticate(session, false, null)).start();
+            }
+        } else if (packet instanceof ServerboundKeyPacket keyPacket) {
+            PrivateKey privateKey = KEY_PAIR.getPrivate();
 
-                SecretKey key = keyPacket.getSecretKey(privateKey);
-                session.setEncryption(protocol.createEncryption(key));
-                new Thread(
-                        () -> authenticate(session, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true), key))
-                        .start();
-            } else if (packet instanceof ServerboundLoginAcknowledgedPacket) {
-                protocol.setOutboundState(ProtocolState.CONFIGURATION);
-                session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
-                keepAliveState = new KeepAliveState();
-                if (session.getFlag(MinecraftConstants.AUTOMATIC_KEEP_ALIVE_MANAGEMENT, true)) {
-                    // If keepalive state is null, lets assume there is no keepalive thread yet
-                    new Thread(() -> keepAlive(session)).start();
-                }
+            if (!Arrays.equals(this.challenge, keyPacket.getEncryptedChallenge(privateKey))) {
+                throw new IllegalStateException("Protocol error");
+            }
 
-                // Credit ViaVersion:
-                // https://github.com/ViaVersion/ViaVersion/blob/dev/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
-                for (Map.Entry<String, Object> entry : networkCodec.entrySet()) {
+            SecretKey key = keyPacket.getSecretKey(privateKey);
+            session.setEncryption(protocol.createEncryption(key));
+            new Thread(
+                    () -> authenticate(session, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true), key))
+                    .start();
+        } else if (packet instanceof ServerboundLoginAcknowledgedPacket) {
+            protocol.setOutboundState(ProtocolState.CONFIGURATION);
+            session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
+            keepAliveState = new KeepAliveState();
+            if (session.getFlag(MinecraftConstants.AUTOMATIC_KEEP_ALIVE_MANAGEMENT, true)) {
+                // If keepalive state is null, lets assume there is no keepalive thread yet
+                new Thread(() -> keepAlive(session)).start();
+            }
+
+            // Credit ViaVersion:
+            // https://github.com/ViaVersion/ViaVersion/blob/dev/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
+            for (Map.Entry<String, Object> entry : networkCodec.entrySet()) {
+                @SuppressWarnings("PatternValidation")
+                NbtMap entryTag = (NbtMap) entry.getValue();
+                @SuppressWarnings("PatternValidation")
+                Key typeTag = Key.key(entryTag.getString("type"));
+                List<NbtMap> valueTag = entryTag.getList("value", NbtType.COMPOUND);
+                List<RegistryEntry> entries = new ArrayList<>();
+                for (NbtMap compoundTag : valueTag) {
                     @SuppressWarnings("PatternValidation")
-                    NbtMap entryTag = (NbtMap) entry.getValue();
-                    @SuppressWarnings("PatternValidation")
-                    Key typeTag = Key.key(entryTag.getString("type"));
-                    List<NbtMap> valueTag = entryTag.getList("value", NbtType.COMPOUND);
-                    List<RegistryEntry> entries = new ArrayList<>();
-                    for (NbtMap compoundTag : valueTag) {
-                        @SuppressWarnings("PatternValidation")
-                        Key nameTag = Key.key(compoundTag.getString("name"));
-                        int id = compoundTag.getInt("id");
-                        entries.add(id, new RegistryEntry(nameTag, compoundTag.getCompound("element")));
-                    }
-
-                    session.send(new ClientboundRegistryDataPacket(typeTag, entries));
+                    Key nameTag = Key.key(compoundTag.getString("name"));
+                    int id = compoundTag.getInt("id");
+                    entries.add(id, new RegistryEntry(nameTag, compoundTag.getCompound("element")));
                 }
 
-                session.send(new ClientboundFinishConfigurationPacket());
+                session.send(new ClientboundRegistryDataPacket(typeTag, entries));
             }
-        } else if (protocol.getInboundState() == ProtocolState.STATUS) {
-            if (packet instanceof ServerboundStatusRequestPacket) {
-                ServerInfoBuilder builder = session.getFlag(MinecraftConstants.SERVER_INFO_BUILDER_KEY);
-                if (builder == null) {
-                    builder = $ -> new ServerStatusInfo(
-                            Component.text("A Minecraft Server"),
-                            new PlayerInfo(0, 20, new ArrayList<>()),
-                            new VersionInfo(protocol.getCodec().getMinecraftVersion(),
-                                    protocol.getCodec().getProtocolVersion()),
-                            null,
-                            false);
-                }
 
-                ServerStatusInfo info = builder.buildInfo(session);
-                session.send(new ClientboundStatusResponsePacket(info));
-            } else if (packet instanceof ServerboundPingRequestPacket pingRequestPacket) {
-                session.send(new ClientboundPongResponsePacket(pingRequestPacket.getPingTime()));
+            session.send(new ClientboundFinishConfigurationPacket());
+        }
+    }
+
+    private void handleStatusPacket(Session session, MinecraftProtocol protocol, Packet packet) {
+        if (packet instanceof ServerboundStatusRequestPacket) {
+            ServerInfoBuilder builder = session.getFlag(MinecraftConstants.SERVER_INFO_BUILDER_KEY);
+            if (builder == null) {
+                builder = $ -> new ServerStatusInfo(
+                        Component.text("A Minecraft Server"),
+                        new PlayerInfo(0, 20, new ArrayList<>()),
+                        new VersionInfo(protocol.getCodec().getMinecraftVersion(),
+                                protocol.getCodec().getProtocolVersion()),
+                        null,
+                        false);
             }
-        } else if (protocol.getInboundState() == ProtocolState.GAME) {
-            if (packet instanceof ServerboundKeepAlivePacket keepAlivePacket) {
-                handleKeepAlive(session, keepAlivePacket);
-            } else if (packet instanceof ServerboundConfigurationAcknowledgedPacket) {
-                // The developer who sends ClientboundStartConfigurationPacket needs to
-                // setOutboundState to CONFIGURATION
-                // after sending the packet. We can't do it in this class because it needs to be
-                // a method call right after it was sent.
-                // Using nettys event loop to change outgoing state may cause differences to
-                // vanilla.
-                session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
-                keepAliveState = new KeepAliveState();
-            } else if (packet instanceof ServerboundPingRequestPacket pingRequestPacket) {
-                session.send(new ClientboundPongResponsePacket(pingRequestPacket.getPingTime()));
-                session.disconnect(Component.translatable("multiplayer.status.request_handled"));
-            }
-        } else if (protocol.getInboundState() == ProtocolState.CONFIGURATION) {
-            if (packet instanceof ServerboundKeepAlivePacket keepAlivePacket) {
-                handleKeepAlive(session, keepAlivePacket);
-            } else if (packet instanceof ServerboundFinishConfigurationPacket) {
-                protocol.setOutboundState(ProtocolState.GAME);
-                session.switchInboundState(() -> protocol.setInboundState(ProtocolState.GAME));
-                keepAliveState = new KeepAliveState();
-                ServerLoginHandler handler = session.getFlag(MinecraftConstants.SERVER_LOGIN_HANDLER_KEY);
-                if (handler != null) {
-                    handler.loggedIn(session);
-                }
+
+            ServerStatusInfo info = builder.buildInfo(session);
+            session.send(new ClientboundStatusResponsePacket(info));
+        } else if (packet instanceof ServerboundPingRequestPacket pingRequestPacket) {
+            session.send(new ClientboundPongResponsePacket(pingRequestPacket.getPingTime()));
+        }
+    }
+
+    private void handleGamePacket(Session session, MinecraftProtocol protocol, Packet packet) {
+        if (packet instanceof ServerboundKeepAlivePacket keepAlivePacket) {
+            handleKeepAlive(session, keepAlivePacket);
+        } else if (packet instanceof ServerboundConfigurationAcknowledgedPacket) {
+            // The developer who sends ClientboundStartConfigurationPacket needs to
+            // setOutboundState to CONFIGURATION
+            // after sending the packet. We can't do it in this class because it needs to be
+            // a method call right after it was sent.
+            // Using nettys event loop to change outgoing state may cause differences to
+            // vanilla.
+            session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
+            keepAliveState = new KeepAliveState();
+        } else if (packet instanceof ServerboundPingRequestPacket pingRequestPacket) {
+            session.send(new ClientboundPongResponsePacket(pingRequestPacket.getPingTime()));
+            session.disconnect(Component.translatable("multiplayer.status.request_handled"));
+        }
+    }
+
+    private void handleConfigurationPacket(Session session, MinecraftProtocol protocol, Packet packet) {
+        if (packet instanceof ServerboundKeepAlivePacket keepAlivePacket) {
+            handleKeepAlive(session, keepAlivePacket);
+        } else if (packet instanceof ServerboundFinishConfigurationPacket) {
+            protocol.setOutboundState(ProtocolState.GAME);
+            session.switchInboundState(() -> protocol.setInboundState(ProtocolState.GAME));
+            keepAliveState = new KeepAliveState();
+            ServerLoginHandler handler = session.getFlag(MinecraftConstants.SERVER_LOGIN_HANDLER_KEY);
+            if (handler != null) {
+                handler.loggedIn(session);
             }
         }
     }

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -58,6 +58,8 @@ import java.util.UUID;
  */
 public class ServerListener extends SessionAdapter {
     private static final int DEFAULT_COMPRESSION_THRESHOLD = 256;
+    private static final long KEEPALIVE_TIMEOUT_MS = 15000L;
+    private static final long KEEPALIVE_TICK_INTERVAL_MS = 50;
 
     // Always empty post-1.7
     private static final String SERVER_ID = "";
@@ -105,7 +107,8 @@ public class ServerListener extends SessionAdapter {
                     }
                     case TRANSFER -> beginLogin(session, protocol, intentionPacket, true);
                     case LOGIN -> beginLogin(session, protocol, intentionPacket, false);
-                    default -> throw new UnsupportedOperationException("Invalid client intent: " + intentionPacket.getIntent());
+                    default -> throw new UnsupportedOperationException(
+                            "Invalid client intent: " + intentionPacket.getIntent());
                 }
             }
         } else if (protocol.getInboundState() == ProtocolState.LOGIN) {
@@ -113,7 +116,8 @@ public class ServerListener extends SessionAdapter {
                 this.username = helloPacket.getUsername();
 
                 if (session.getFlag(MinecraftConstants.ENCRYPT_CONNECTION, true)) {
-                    session.send(new ClientboundHelloPacket(SERVER_ID, KEY_PAIR.getPublic(), this.challenge, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true)));
+                    session.send(new ClientboundHelloPacket(SERVER_ID, KEY_PAIR.getPublic(), this.challenge,
+                            session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true)));
                 } else {
                     new Thread(() -> authenticate(session, false, null)).start();
                 }
@@ -126,7 +130,9 @@ public class ServerListener extends SessionAdapter {
 
                 SecretKey key = keyPacket.getSecretKey(privateKey);
                 session.setEncryption(protocol.createEncryption(key));
-                new Thread(() -> authenticate(session, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true), key)).start();
+                new Thread(
+                        () -> authenticate(session, session.getFlag(MinecraftConstants.SHOULD_AUTHENTICATE, true), key))
+                        .start();
             } else if (packet instanceof ServerboundLoginAcknowledgedPacket) {
                 protocol.setOutboundState(ProtocolState.CONFIGURATION);
                 session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
@@ -136,7 +142,8 @@ public class ServerListener extends SessionAdapter {
                     new Thread(() -> keepAlive(session)).start();
                 }
 
-                // Credit ViaVersion: https://github.com/ViaVersion/ViaVersion/blob/dev/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
+                // Credit ViaVersion:
+                // https://github.com/ViaVersion/ViaVersion/blob/dev/common/src/main/java/com/viaversion/viaversion/protocols/protocol1_20_5to1_20_3/rewriter/EntityPacketRewriter1_20_5.java
                 for (Map.Entry<String, Object> entry : networkCodec.entrySet()) {
                     @SuppressWarnings("PatternValidation")
                     NbtMap entryTag = (NbtMap) entry.getValue();
@@ -163,10 +170,10 @@ public class ServerListener extends SessionAdapter {
                     builder = $ -> new ServerStatusInfo(
                             Component.text("A Minecraft Server"),
                             new PlayerInfo(0, 20, new ArrayList<>()),
-                            new VersionInfo(protocol.getCodec().getMinecraftVersion(), protocol.getCodec().getProtocolVersion()),
+                            new VersionInfo(protocol.getCodec().getMinecraftVersion(),
+                                    protocol.getCodec().getProtocolVersion()),
                             null,
-                            false
-                    );
+                            false);
                 }
 
                 ServerStatusInfo info = builder.buildInfo(session);
@@ -178,9 +185,12 @@ public class ServerListener extends SessionAdapter {
             if (packet instanceof ServerboundKeepAlivePacket keepAlivePacket) {
                 handleKeepAlive(session, keepAlivePacket);
             } else if (packet instanceof ServerboundConfigurationAcknowledgedPacket) {
-                // The developer who sends ClientboundStartConfigurationPacket needs to setOutboundState to CONFIGURATION
-                // after sending the packet. We can't do it in this class because it needs to be a method call right after it was sent.
-                // Using nettys event loop to change outgoing state may cause differences to vanilla.
+                // The developer who sends ClientboundStartConfigurationPacket needs to
+                // setOutboundState to CONFIGURATION
+                // after sending the packet. We can't do it in this class because it needs to be
+                // a method call right after it was sent.
+                // Using nettys event loop to change outgoing state may cause differences to
+                // vanilla.
                 session.switchInboundState(() -> protocol.setInboundState(ProtocolState.CONFIGURATION));
                 keepAliveState = new KeepAliveState();
             } else if (packet instanceof ServerboundPingRequestPacket pingRequestPacket) {
@@ -205,24 +215,29 @@ public class ServerListener extends SessionAdapter {
     private void handleKeepAlive(Session session, ServerboundKeepAlivePacket keepAlivePacket) {
         KeepAliveState currentKeepAliveState = this.keepAliveState;
         if (currentKeepAliveState != null) {
-            if (currentKeepAliveState.keepAlivePending && keepAlivePacket.getPingId() == currentKeepAliveState.keepAliveChallenge) {
+            if (currentKeepAliveState.keepAlivePending
+                    && keepAlivePacket.getPingId() == currentKeepAliveState.keepAliveChallenge) {
                 currentKeepAliveState.keepAlivePending = false;
-                session.setFlag(MinecraftConstants.PING_KEY, System.currentTimeMillis() - currentKeepAliveState.keepAliveTime);
+                session.setFlag(MinecraftConstants.PING_KEY,
+                        System.currentTimeMillis() - currentKeepAliveState.keepAliveTime);
             } else {
                 session.disconnect(Component.translatable("disconnect.timeout"));
             }
         }
     }
 
-    private void beginLogin(Session session, MinecraftProtocol protocol, ClientIntentionPacket packet, boolean transferred) {
+    private void beginLogin(Session session, MinecraftProtocol protocol, ClientIntentionPacket packet,
+            boolean transferred) {
         isTransfer = transferred;
         protocol.setOutboundState(ProtocolState.LOGIN);
         if (transferred && !session.getFlag(MinecraftConstants.ACCEPT_TRANSFERS_KEY)) {
             session.disconnect(Component.translatable("multiplayer.disconnect.transfers_disabled"));
         } else if (packet.getProtocolVersion() > protocol.getCodec().getProtocolVersion()) {
-            session.disconnect(Component.translatable("multiplayer.disconnect.incompatible", Component.text(protocol.getCodec().getMinecraftVersion())));
+            session.disconnect(Component.translatable("multiplayer.disconnect.incompatible",
+                    Component.text(protocol.getCodec().getMinecraftVersion())));
         } else if (packet.getProtocolVersion() < protocol.getCodec().getProtocolVersion()) {
-            session.disconnect(Component.translatable("multiplayer.disconnect.outdated_client", Component.text(protocol.getCodec().getMinecraftVersion())));
+            session.disconnect(Component.translatable("multiplayer.disconnect.outdated_client",
+                    Component.text(protocol.getCodec().getMinecraftVersion())));
         } else {
             session.switchInboundState(() -> protocol.setInboundState(ProtocolState.LOGIN));
         }
@@ -242,9 +257,11 @@ public class ServerListener extends SessionAdapter {
     private void authenticate(Session session, boolean shouldAuthenticate, SecretKey key) {
         GameProfile profile;
         if (shouldAuthenticate && key != null) {
-            SessionService sessionService = session.getFlag(MinecraftConstants.SESSION_SERVICE_KEY, new SessionService());
+            SessionService sessionService = session.getFlag(MinecraftConstants.SESSION_SERVICE_KEY,
+                    new SessionService());
             try {
-                profile = sessionService.getProfileByServer(username, SessionService.getServerId(SERVER_ID, KEY_PAIR.getPublic(), key));
+                profile = sessionService.getProfileByServer(username,
+                        SessionService.getServerId(SERVER_ID, KEY_PAIR.getPublic(), key));
             } catch (IOException e) {
                 session.disconnect(Component.translatable("multiplayer.disconnect.authservers_down"), e);
                 return;
@@ -262,8 +279,8 @@ public class ServerListener extends SessionAdapter {
 
         int threshold = session.getFlag(MinecraftConstants.SERVER_COMPRESSION_THRESHOLD, DEFAULT_COMPRESSION_THRESHOLD);
         if (threshold >= 0) {
-            session.send(new ClientboundLoginCompressionPacket(threshold), () ->
-                session.setCompression(new CompressionConfig(threshold, new ZlibCompression(), true)));
+            session.send(new ClientboundLoginCompressionPacket(threshold),
+                    () -> session.setCompression(new CompressionConfig(threshold, new ZlibCompression(), true)));
         }
 
         session.send(new ClientboundLoginFinishedPacket(profile));
@@ -273,7 +290,7 @@ public class ServerListener extends SessionAdapter {
         while (session.isConnected()) {
             KeepAliveState currentKeepAliveState = this.keepAliveState;
             if (currentKeepAliveState != null) {
-                if (System.currentTimeMillis() - currentKeepAliveState.keepAliveTime >= 15000L) {
+                if (System.currentTimeMillis() - currentKeepAliveState.keepAliveTime >= KEEPALIVE_TIMEOUT_MS) {
                     if (currentKeepAliveState.keepAlivePending) {
                         session.disconnect(Component.translatable("disconnect.timeout"));
                         break;
@@ -290,7 +307,7 @@ public class ServerListener extends SessionAdapter {
 
             // TODO: Implement proper tick loop rather than sleeping
             try {
-                Thread.sleep(50);
+                Thread.sleep(KEEPALIVE_TICK_INTERVAL_MS);
             } catch (InterruptedException e) {
                 break;
             }


### PR DESCRIPTION
This PR introduces a series of localized refactorings to improve code readability and maintainability. All changes are strictly behavior-preserving and introduce zero logic changes. The project compiles successfully and all tests pass.This PR introduces a series of localized refactorings to improve code readability and maintainability as part of an academic assignment. All changes are strictly behavior-preserving and introduce zero logic changes. The project compiles successfully and all tests pass.

In response to developer feedback advising that smaller code clarity changes be kept separate from larger structural overhauls, these 3 code-level improvements have been isolated in this PR:

1. **Extract Method:** Split the massive 107-line [packetReceived](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:97:4-107:5) method in [ServerListener.java](cci:7://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:0:0-0:0) into smaller, dedicated handler methods for each protocol state ([handleHandshakePacket](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:109:4-122:5), [handleLoginPacket](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:124:4-176:5), [handleStatusPacket](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:178:4-196:5), [handleGamePacket](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:198:4-214:5), [handleConfigurationPacket](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:216:4-228:5)).
2. **Introduce Explaining Variable:** Extracted the complex inline string formatting and URI creation in [SessionService.java](cci:7://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/auth/SessionService.java:0:0-0:0) ([getProfileByServer](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/auth/SessionService.java:65:4-89:5) and [fillProfileProperties](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/auth/SessionService.java:91:4-111:5)) into named `URI` local variables (`profileUri` and `serverUri`) to improve readability of the `HTTPUtils.makeRequest` calls.
3. **Rename Variable / Extract Constant:** Replaced the magic numbers `15000L` and `50` in [ServerListener.java](cci:7://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:0:0-0:0)'s [keepAlive()](cci:1://file:///Users/mansimanojpatil/Desktop/Pretty/ATSD/MCProtocolLib/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java:304:4-330:5) method with properly named contextual constants (`KEEPALIVE_TIMEOUT_MS` and `KEEPALIVE_TICK_INTERVAL_MS`).
