### PR TITLE
fix(MinecraftTypes): handle empty `EnumSet` in `readEnumSet`

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
@@ -1795,7 +1795,7 @@ public class MinecraftTypes {
         MinecraftTypes.writeDataPalette(buf, section.getBiomeData());
     }
 
-    public static <E extends Enum<E>> EnumSet<E> readEnumSet(ByteBuf buf, E[] values) {
+    public static <E extends Enum<E>> EnumSet<E> readEnumSet(ByteBuf buf, Class<E> type, E[] values) {
         BitSet bitSet = MinecraftTypes.readFixedBitSet(buf, values.length);
         List<E> readValues = new ArrayList<>();
 
@@ -1805,7 +1805,9 @@ public class MinecraftTypes {
             }
         }
 
-        return EnumSet.copyOf(readValues);
+        return readValues.isEmpty()
+            ? EnumSet.noneOf(type)
+            : EnumSet.copyOf(readValues);
     }
 
     public static <E extends Enum<E>> void writeEnumSet(ByteBuf buf, EnumSet<E> enumSet, E[] values) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/MinecraftTypes.java
@@ -1795,19 +1795,18 @@ public class MinecraftTypes {
         MinecraftTypes.writeDataPalette(buf, section.getBiomeData());
     }
 
-    public static <E extends Enum<E>> EnumSet<E> readEnumSet(ByteBuf buf, Class<E> type, E[] values) {
+    public static <E extends Enum<E>> EnumSet<E> readEnumSet(ByteBuf buf, Class<E> type) {
+        E[] values = type.getEnumConstants();
         BitSet bitSet = MinecraftTypes.readFixedBitSet(buf, values.length);
-        List<E> readValues = new ArrayList<>();
+        EnumSet<E> result = EnumSet.noneOf(type);
 
         for (int i = 0; i < values.length; i++) {
             if (bitSet.get(i)) {
-                readValues.add(values[i]);
+                result.add(values[i]);
             }
         }
 
-        return readValues.isEmpty()
-            ? EnumSet.noneOf(type)
-            : EnumSet.copyOf(readValues);
+        return result;
     }
 
     public static <E extends Enum<E>> void writeEnumSet(ByteBuf buf, EnumSet<E> enumSet, E[] values) {

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/packet/ingame/clientbound/ClientboundPlayerInfoUpdatePacket.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/packet/ingame/clientbound/ClientboundPlayerInfoUpdatePacket.java
@@ -26,7 +26,7 @@ public class ClientboundPlayerInfoUpdatePacket implements MinecraftPacket {
     private final PlayerListEntry[] entries;
 
     public ClientboundPlayerInfoUpdatePacket(ByteBuf in) {
-        this.actions = MinecraftTypes.readEnumSet(in, PlayerListEntryAction.VALUES);
+        this.actions = MinecraftTypes.readEnumSet(in, PlayerListEntryAction.class, PlayerListEntryAction.VALUES);
         this.entries = new PlayerListEntry[MinecraftTypes.readVarInt(in)];
         for (int count = 0; count < this.entries.length; count++) {
             PlayerListEntry entry = new PlayerListEntry(MinecraftTypes.readUUID(in));

--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/packet/ingame/clientbound/ClientboundPlayerInfoUpdatePacket.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/packet/ingame/clientbound/ClientboundPlayerInfoUpdatePacket.java
@@ -26,7 +26,7 @@ public class ClientboundPlayerInfoUpdatePacket implements MinecraftPacket {
     private final PlayerListEntry[] entries;
 
     public ClientboundPlayerInfoUpdatePacket(ByteBuf in) {
-        this.actions = MinecraftTypes.readEnumSet(in, PlayerListEntryAction.class, PlayerListEntryAction.VALUES);
+        this.actions = MinecraftTypes.readEnumSet(in, PlayerListEntryAction.class);
         this.entries = new PlayerListEntry[MinecraftTypes.readVarInt(in)];
         for (int count = 0; count < this.entries.length; count++) {
             PlayerListEntry entry = new PlayerListEntry(MinecraftTypes.readUUID(in));


### PR DESCRIPTION
when trying to connect to 1.20.6 using ViaProxy it produces `java.lang.IllegalArgumentException: Collection is empty`