### PR TITLE
Fix ServerboundSpectatorActionPacket to match vanilla OPTIONAL_VAR_INT

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/packet/ingame/serverbound/player/ServerboundSpectatorActionPacket.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/packet/ingame/serverbound/player/ServerboundSpectatorActionPacket.java
@@ -16,21 +16,13 @@ public class ServerboundSpectatorActionPacket implements MinecraftPacket {
     private final OptionalInt entityId;
 
     public ServerboundSpectatorActionPacket(ByteBuf in) {
-        if (in.readBoolean()) {
-            this.entityId = OptionalInt.of(MinecraftTypes.readVarInt(in));
-        } else {
-            this.entityId = OptionalInt.empty();
-        }
+        int i = MinecraftTypes.readVarInt(in);
+        this.entityId = i == 0 ? OptionalInt.empty() : OptionalInt.of(i - 1);
     }
 
     @Override
     public void serialize(ByteBuf out) {
-        if (this.entityId.isPresent()) {
-            out.writeBoolean(true);
-            MinecraftTypes.writeVarInt(out, this.entityId.getAsInt());
-        } else {
-            out.writeBoolean(false);
-        }
+        MinecraftTypes.writeVarInt(out, this.entityId.isPresent() ? this.entityId.getAsInt() + 1 : 0);
     }
 
     @Override


### PR DESCRIPTION
It was serialized as a boolean + VarInt, but vanilla uses `ByteBufCodecs.OPTIONAL_VAR_INT` (a single VarInt: `0` = empty, `n` = `of(n-1)`). The extra leading byte desyncs the stream, so a real 26.2 server rejects the packet and disconnects. No API change.