### PR TITLE
Don't disconnect clients that send ping requests in PLAY state

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/ServerListener.java
@@ -188,6 +188,7 @@ public class ServerListener extends SessionAdapter {
             session.send(new ClientboundStatusResponsePacket(info));
         } else if (packet instanceof ServerboundPingRequestPacket pingRequestPacket) {
             session.send(new ClientboundPongResponsePacket(pingRequestPacket.getPingTime()));
+            session.disconnect(Component.translatable("multiplayer.status.request_handled"));
         }
     }
 
@@ -202,7 +203,6 @@ public class ServerListener extends SessionAdapter {
             keepAliveState = new KeepAliveState();
         } else if (packet instanceof ServerboundPingRequestPacket pingRequestPacket) {
             session.send(new ClientboundPongResponsePacket(pingRequestPacket.getPingTime()));
-            session.disconnect(Component.translatable("multiplayer.status.request_handled"));
         }
     }
 


### PR DESCRIPTION
I'm assuming this was some sort of copy-paste error, as you are supposed to disconnect them in the STATUS state, not the PLAY state, which is the opposite of what was being done in ServerListener.