### PR TITLE
Serialize the hat flag of player head components as a boolean

### DIFF
--- a/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/NbtComponentSerializer.java
+++ b/protocol/src/main/java/org/geysermc/mcprotocollib/protocol/codec/NbtComponentSerializer.java
@@ -32,7 +32,8 @@ public class NbtComponentSerializer {
             "italic",
             "underlined",
             "strikethrough",
-            "obfuscated"
+            "obfuscated",
+            "hat"
     );
     // Order is important
     private static final List<Pair<String, String>> COMPONENT_TYPES = List.of(

--- a/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/codec/NbtComponentSerializerTest.java
+++ b/protocol/src/test/java/org/geysermc/mcprotocollib/protocol/codec/NbtComponentSerializerTest.java
@@ -1,0 +1,49 @@
+package org.geysermc.mcprotocollib.protocol.codec;
+
+import com.google.gson.JsonObject;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import net.kyori.adventure.text.ObjectComponent;
+import net.kyori.adventure.text.object.PlayerHeadObjectContents;
+import org.cloudburstmc.nbt.NbtMap;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class NbtComponentSerializerTest {
+
+    @Test
+    public void hatFlagSerializesAsBoolean() {
+        JsonObject json = NbtComponentSerializer.tagComponentToJson(playerHeadComponent((byte) 1)).getAsJsonObject();
+
+        assertTrue(json.get("hat").isJsonPrimitive());
+        assertTrue(json.get("hat").getAsJsonPrimitive().isBoolean());
+        assertTrue(json.get("hat").getAsBoolean());
+    }
+
+    @Test
+    public void readComponentAcceptsHatFlag() {
+        ByteBuf buf = Unpooled.buffer();
+        try {
+            MinecraftTypes.writeAnyTag(buf, playerHeadComponent((byte) 0));
+
+            // Deserialization is strict about boolean fields; a hat flag crossing
+            // the NBT to JSON conversion as a number fails here.
+            ObjectComponent component = assertInstanceOf(ObjectComponent.class, MinecraftTypes.readComponent(buf));
+            PlayerHeadObjectContents contents = assertInstanceOf(PlayerHeadObjectContents.class, component.contents());
+            assertFalse(contents.hat());
+        } finally {
+            buf.release();
+        }
+    }
+
+    private static NbtMap playerHeadComponent(byte hat) {
+        return NbtMap.builder()
+                .putString("type", "object")
+                .putString("player", "0123456789abcdef0123456789abcdef")
+                .putByte("hat", hat)
+                .build();
+    }
+}


### PR DESCRIPTION
Java 26.2's player head chat components carry a `hat` boolean. It is missing from `NbtComponentSerializer.BOOLEAN_TYPES`, so the NBT byte is converted to a JSON number, and the strict adventure deserialization in `MinecraftTypes.readComponent` then rejects the component:

```
java.lang.IllegalStateException: Expected BOOLEAN but was NUMBER at path $.extra[0].extra[0].extra[0].hat
```

Observed in production through Geyser with a chat plugin that renders player heads in chat: every message containing a head component fails to translate for Bedrock players and the packet is dropped. Adding `hat` to the boolean key set fixes the round trip. As far as I can tell it is the only boolean field the 26.2 component additions introduced; the sprite object component's new fields are strings.

Includes a test covering both the conversion helper and the full `readComponent` path with a real player head component. Targeting `feature/26.2` since the field only exists there.